### PR TITLE
fix: replace throws with warnings for missing botToken and botUsername in config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to the better-auth-telegram plugin will be documented in thi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.1]
+
+### Fixed
+
+- **Configuration validation now warns instead of throwing** — `botToken` and `botUsername` are no longer required at plugin initialization. If missing, the plugin emits `console.warn()` instead of throwing an error. Login Widget and Mini App endpoints will still throw `APIError` at runtime if these values are missing, but the plugin itself won't crash your Better Auth setup during config. Useful for OIDC-only deployments where bot credentials aren't needed.
+
+### Changed
+
+- **API reference documentation updated** — reflects new optional validation behavior for `botToken` and `botUsername`.
+
 ## [1.5.0] - 2026-03-10
 
 ### Added

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -19,7 +19,7 @@ Everything you never knew you needed to know about `better-auth-telegram`, laid 
 
 ### `telegram(options)`
 
-The main server plugin function. Returns a `BetterAuthPlugin` object. If you forget `botToken`, it throws immediately -- no silent failures here.
+The main server plugin function. Returns a `BetterAuthPlugin` object.
 
 ```typescript
 import { telegram } from "better-auth-telegram";
@@ -33,16 +33,16 @@ const plugin = telegram({
 
 #### Options: `TelegramPluginOptions`
 
-| Option | Type | Default | Description |
-|---|---|---|---|
-| `botToken` | `string` | **required** | Bot token from @BotFather. The plugin throws if missing. |
-| `botUsername` | `string` | **required** | Bot username without the `@`. Also throws if missing. |
-| `allowUserToLink` | `boolean` | `true` | Allow authenticated users to link their Telegram account. |
-| `autoCreateUser` | `boolean` | `true` | Auto-create a user when a new Telegram user signs in. |
-| `maxAuthAge` | `number` | `86400` (24 hours) | Maximum age of `auth_date` in seconds. Prevents replay attacks. |
-| `mapTelegramDataToUser` | `(data: TelegramAuthData) => UserData` | Uses `first_name`/`last_name` for name, `photo_url` for image | Custom mapping from Telegram data to your user object. |
-| `miniApp` | `object` | `undefined` | Telegram Mini Apps configuration. See below. |
-| `oidc` | `TelegramOIDCOptions` | `undefined` | Telegram OIDC configuration. See below. |
+| Option | Type | Default | Description                                                                                  |
+|---|---|---|----------------------------------------------------------------------------------------------|
+| `botToken` | `string` | **required** | Bot token from @BotFather. The plugin warns if missing.                                      |
+| `botUsername` | `string` | **required** | Bot username without the `@`. Also warns if missing.                                        |
+| `allowUserToLink` | `boolean` | `true` | Allow authenticated users to link their Telegram account.                                    |
+| `autoCreateUser` | `boolean` | `true` | Auto-create a user when a new Telegram user signs in.                                        |
+| `maxAuthAge` | `number` | `86400` (24 hours) | Maximum age of `auth_date` in seconds. Prevents replay attacks.                              |
+| `mapTelegramDataToUser` | `(data: TelegramAuthData) => UserData` | Uses `first_name`/`last_name` for name, `photo_url` for image | Custom mapping from Telegram data to your user object.                                       |
+| `miniApp` | `object` | `undefined` | Telegram Mini Apps configuration. See below.                                                 |
+| `oidc` | `TelegramOIDCOptions` | `undefined` | Telegram OIDC configuration. See below.                                                      |
 | `testMode` | `boolean` | `false` | Enable Telegram test server mode. Widget uses test environment; HMAC verification unchanged. |
 
 ##### `miniApp` Options

--- a/src/oidc.test.ts
+++ b/src/oidc.test.ts
@@ -4,6 +4,7 @@
 import { exportJWK, generateKeyPair, SignJWT } from "jose";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  ERROR_CODES,
   TELEGRAM_OIDC_AUTH_ENDPOINT,
   TELEGRAM_OIDC_ISSUER,
   TELEGRAM_OIDC_JWKS_URI,
@@ -1379,28 +1380,42 @@ describe("Adversarial: config endpoint shape with testMode", () => {
 });
 
 describe("Adversarial: plugin constructor error cases", () => {
-  it("should throw when botToken is empty string", async () => {
+  it("should warn when botToken is empty string", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const { telegram } = await import("./index");
-    expect(() => telegram({ botToken: "", botUsername: "test_bot" })).toThrow();
+    telegram({ botToken: "", botUsername: "test_bot" });
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("botToken"));
+    warnSpy.mockRestore();
   });
 
-  it("should throw when botUsername is empty string", async () => {
+  it("should warn when botUsername is empty string", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const { telegram } = await import("./index");
-    expect(() => telegram({ botToken: BOT_TOKEN, botUsername: "" })).toThrow();
-  });
-
-  it("should throw the specific BOT_TOKEN_REQUIRED message", async () => {
-    const { telegram } = await import("./index");
-    expect(() => telegram({ botToken: "", botUsername: "test_bot" })).toThrow(
-      "Telegram plugin: botToken is required"
+    telegram({ botToken: BOT_TOKEN, botUsername: "" });
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("botUsername")
     );
+    warnSpy.mockRestore();
   });
 
-  it("should throw the specific BOT_USERNAME_REQUIRED message", async () => {
+  it("should warn when botToken is missing", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const { telegram } = await import("./index");
-    expect(() => telegram({ botToken: BOT_TOKEN, botUsername: "" })).toThrow(
-      "Telegram plugin: botUsername is required"
+    telegram({ botToken: "", botUsername: "test_bot" });
+    expect(warnSpy).toHaveBeenCalledWith(
+      `[better-auth-telegram] ${ERROR_CODES.BOT_TOKEN_REQUIRED.message}`
     );
+    warnSpy.mockRestore();
+  });
+
+  it("should warn when botUsername is missing", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { telegram } = await import("./index");
+    telegram({ botToken: BOT_TOKEN, botUsername: "" });
+    expect(warnSpy).toHaveBeenCalledWith(
+      `[better-auth-telegram] ${ERROR_CODES.BOT_USERNAME_REQUIRED.message}`
+    );
+    warnSpy.mockRestore();
   });
 });
 

--- a/src/plugin-config.test.ts
+++ b/src/plugin-config.test.ts
@@ -10,16 +10,22 @@ const BASE = {
 describe("createPluginConfig", () => {
   // ── Validation ─────────────────────────────────────────────────────
 
-  it("throws when botToken is missing", () => {
-    expect(() =>
-      createPluginConfig({ botToken: "", botUsername: "bot" })
-    ).toThrow(ERROR_CODES.BOT_TOKEN_REQUIRED.message);
+  it("warns when botToken is missing", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    createPluginConfig({ botToken: "", botUsername: "bot" });
+    expect(warnSpy).toHaveBeenCalledWith(
+      `[better-auth-telegram] ${ERROR_CODES.BOT_TOKEN_REQUIRED.message}`
+    );
+    warnSpy.mockRestore();
   });
 
-  it("throws when botUsername is missing", () => {
-    expect(() =>
-      createPluginConfig({ botToken: "tok:en", botUsername: "" })
-    ).toThrow(ERROR_CODES.BOT_USERNAME_REQUIRED.message);
+  it("warns when botUsername is missing", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    createPluginConfig({ botToken: "tok:en", botUsername: "" });
+    expect(warnSpy).toHaveBeenCalledWith(
+      `[better-auth-telegram] ${ERROR_CODES.BOT_USERNAME_REQUIRED.message}`
+    );
+    warnSpy.mockRestore();
   });
 
   // ── Defaults ───────────────────────────────────────────────────────

--- a/src/plugin-config.ts
+++ b/src/plugin-config.ts
@@ -39,7 +39,7 @@ export interface TelegramPluginConfig {
 
 /**
  * Parses and validates `TelegramPluginOptions`, applying defaults.
- * Throws if required fields (`botToken`, `botUsername`) are missing.
+ * Warns if required fields (`botToken`, `botUsername`) are missing.
  */
 export function createPluginConfig(
   options: TelegramPluginOptions
@@ -58,11 +58,15 @@ export function createPluginConfig(
   } = options;
 
   if (!botToken) {
-    throw new Error(ERROR_CODES.BOT_TOKEN_REQUIRED.message);
+    console.warn(
+      `[better-auth-telegram] ${ERROR_CODES.BOT_TOKEN_REQUIRED.message}`
+    );
   }
 
   if (!botUsername) {
-    throw new Error(ERROR_CODES.BOT_USERNAME_REQUIRED.message);
+    console.warn(
+      `[better-auth-telegram] ${ERROR_CODES.BOT_USERNAME_REQUIRED.message}`
+    );
   }
 
   const widgetEnabled = loginWidget !== false;
@@ -76,8 +80,8 @@ export function createPluginConfig(
   }
 
   return {
-    botToken,
-    botUsername,
+    botToken: botToken ?? "",
+    botUsername: botUsername ?? "",
     widgetEnabled,
     miniAppEnabled,
     oidcEnabled,


### PR DESCRIPTION
## What fresh chaos is this?

Replaced `throw` statements with `console.warn()` for missing `botToken` and `botUsername` during plugin initialization.

**Why this matters:** Better Auth plugins that depend on external tokens (API keys, bot tokens, secrets) should not throw at initialization time. The pattern across the `better-auth` ecosystem is to warn when credentials are missing, then fail gracefully at runtime when the affected endpoints are actually called.

**The reasoning:**

1. **Runtime-resolved environment variables** — Some platforms resolve `process.env` values at runtime, not at initialization. Convex is a prime example: environment variables are `undefined` during the "compile" phase and only available when the function actually executes. Throwing at init breaks the entire auth setup before the runtime even has a chance to provide the credentials.

2. **Consistency with Better Auth core** — Plugins like `discord`, `github`, `google` in the main repo all warn on missing credentials rather than throwing. This plugin was the odd one out.


## Nature of the beast

- [x] Bug fix (something was broken and you, heroically, fixed it)
- [ ] New feature (you added something nobody asked for but everyone needed)
- [ ] Breaking change (you chose violence)
- [ ] Documentation update (the rarest contribution in open source)
- [ ] Refactoring (you moved things around and called it progress)

## The bare minimum

- [x] Tests pass (`npm test`) -- yes, all of them
- [x] Types check (`npm run type-check`) -- TypeScript is not optional here
- [x] Lint passes (`npm run lint`) -- Biome has no feelings to hurt
- [x] New code has tests (I will notice if it doesn't)
- [x] Coverage stays above 90% (I don't make the rules -- actually I do)
- [x] Docs updated (if applicable, which it probably is, which you probably skipped)
- [x] `CHANGELOG.md` updated (future you will thank present you)

## Proof of life

No new tests required — this change aligns behavior with the existing Better Auth plugin pattern. Plugins should warn at init, not throw. The actual endpoint protection (throwing `APIError` when credentials are missing at runtime) remains tested and unchanged.

## Relevant wreckage

No issue created — the scope is small enough to explain here. This brings the plugin in line with how all other Better Auth plugins handle missing credentials.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Changed**
  * Configuration validation for `botToken` and `botUsername` now emits console warnings instead of throwing errors during plugin initialization; validation still occurs at Login Widget and Mini App endpoints at runtime.

* **Documentation**
  * Updated API reference documentation to reflect the optional validation behavior during plugin setup.

* **Tests**
  * Updated test cases to verify warning emissions instead of error throws.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->