### PR TITLE
Add 'id' field to Telegram OIDC claims type definition

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -66,6 +66,7 @@ export interface TelegramOIDCClaims {
   picture?: string;
   preferred_username?: string;
   sub: string;
+  id: string;
 }
 
 /**


### PR DESCRIPTION
## What fresh chaos is this?

https://core.telegram.org/bots/telegram-login#user-data-structure

Add 'id' field to Telegram OIDC claims type definition

<!-- Describe what you did and why. Spare me the novel. -->

## Nature of the beast

- [ ] Bug fix (something was broken and you, heroically, fixed it)
- [ ] New feature (you added something nobody asked for but everyone needed)
- [ ] Breaking change (you chose violence)
- [ ] Documentation update (the rarest contribution in open source)
- [ ] Refactoring (you moved things around and called it progress)

## The bare minimum

- [ ] Tests pass (`npm test`) -- yes, all of them
- [ ] Types check (`npm run type-check`) -- TypeScript is not optional here
- [ ] Lint passes (`npm run lint`) -- Biome has no feelings to hurt
- [ ] New code has tests (I will notice if it doesn't)
- [ ] Coverage stays above 90% (I don't make the rules -- actually I do)
- [ ] Docs updated (if applicable, which it probably is, which you probably skipped)
- [ ] `CHANGELOG.md` updated (future you will thank present you)

## Proof of life

<!-- How did you test this? "It works on my machine" is not a testing strategy. -->

## Relevant wreckage

<!-- Link related issues: Fixes #123, Closes #456 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added required identifier field to authentication claims.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->