### PR TITLE
release: better-auth-telegram v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to the better-auth-telegram plugin will be documented in thi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] - 2026-07-29
+
+### Added
+
+- **Mini App launch-parameter fallback** ([#26](https://github.com/vcode-sh/better-auth-telegram/issues/26)) — `autoSignInFromMiniApp()` now prefers the Telegram SDK's `initData` and falls back to `tgWebAppData` from the URL fragment when the SDK object is unavailable.
+- **Current Telegram OIDC claim types** — `TelegramOIDCClaims` now includes optional `id`, `given_name`, `family_name`, and `phone_number_verified` claims.
+
+### Fixed
+
+- **Flow-aware credentials** ([#19](https://github.com/vcode-sh/better-auth-telegram/pull/19)) — `botToken` and `botUsername` no longer abort plugin initialization when their flows are disabled or secrets are injected later. Enabled flows warn during setup and reject at the request boundary if a required credential is still missing.
+- **OIDC algorithm validation** — ID-token verification now allows Telegram's documented `RS256`, `ES256`, and `EdDSA` algorithms, rejects unsupported algorithms before fetching JWKS, and requires the selected JWK algorithm to match the token header.
+
+### Changed
+
+- **Dependency security floor** — the Better Auth peer range is now `>=1.6.22 <1.7.0`, and affected development dependencies were updated to patched versions. This is a breaking requirement for projects still using Better Auth 1.5 or older 1.6 releases.
+- Test count: 261 → 344. The new coverage focuses on credential boundaries, Mini App launch data, current OIDC claims, and supported signing algorithms.
+
+### Security
+
+- Placeholder Telegram OIDC emails remain unverified. Telegram does not return an email claim, so the plugin will not mark a generated `{sub}@telegram.oidc` address as verified.
+
 ## [1.5.0] - 2026-03-10
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ Two entry points, two export paths:
 Supporting modules:
 
 - **`src/verify.ts`** -- HMAC-SHA256 verification via Web Crypto API. Two paths: Login Widget (`SHA256(botToken)`) and Mini App (`HMAC-SHA256("WebAppData", botToken)`)
-- **`src/oidc.ts`** -- Telegram OIDC provider factory. Creates an `OAuthProvider` for Better Auth's social login system using OAuth 2.0 Authorization Code flow with PKCE via `oauth.telegram.org`. RS256 JWT verification via JWKS.
+- **`src/oidc.ts`** -- Telegram OIDC provider factory. Creates an `OAuthProvider` for Better Auth's social login system using OAuth 2.0 Authorization Code flow with PKCE via `oauth.telegram.org`. Allowlisted JWT verification via JWKS.
 - **`src/types.ts`** -- All TypeScript interfaces (`TelegramPluginOptions`, `TelegramAuthData`, Mini App types, `TelegramOIDCOptions`, `TelegramOIDCClaims`)
 - **`src/constants.ts`** -- Error codes, success messages, `PLUGIN_ID`, `DEFAULT_MAX_AUTH_AGE`, OIDC endpoints/issuer constants
 
@@ -62,7 +62,7 @@ Single test file: `npx vitest run src/verify.test.ts`
 
 ## Dependencies
 
-**Runtime (peer):** `better-auth` (^1.4.18)
+**Runtime (peer):** `better-auth` (`>=1.6.22 <1.7.0`)
 
 **Build external:** `better-auth`, `zod` (tsup external)
 

--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@ Telegram authentication plugin for [Better Auth](https://better-auth.com). Login
 
 Built on Web Crypto API — works in Node, Bun, Cloudflare Workers, and whatever edge runtime you're pretending to need. No `node:crypto` tantrums.
 
-261 tests. 100% coverage. If it breaks, roast me on [X](https://x.com/vcode_sh). If it works, also roast me. I'm there either way, posting through the pain.
+344 tests. If it breaks, roast me on [X](https://x.com/vcode_sh). If it works, also roast me. I'm there either way, posting through the pain.
 
 ## Requirements
 
 - Node.js >= 22 (or Bun, or any runtime with Web Crypto API)
-- `better-auth@^1.5.0`
+- `better-auth@>=1.6.22 <1.7.0`
 
 ## Install
 
@@ -70,7 +70,7 @@ model User {
   // ... existing fields
   telegramId          String?
   telegramUsername    String?
-  telegramPhoneNumber String?  // populated via OIDC with phone scope
+  telegramPhoneNumber String?  // persist claims.phone_number via a custom OIDC mapper
 }
 
 model Account {
@@ -162,7 +162,7 @@ const validation = await authClient.validateMiniApp(
 
 ### OIDC (OpenID Connect)
 
-Standard OAuth 2.0 flow via `oauth.telegram.org`. Phone numbers, PKCE, RS256 JWTs — proper grown-up auth instead of widget callbacks. Telegram finally joined the federation.
+Standard OAuth 2.0 flow via `oauth.telegram.org`. Phone numbers, PKCE, and signed JWTs — proper grown-up auth instead of widget callbacks. Telegram now labels the old iframe widget as legacy, so use OIDC for new browser integrations.
 
 #### Prerequisites
 
@@ -189,6 +189,7 @@ telegram({
   botUsername: "your_bot_username",
   oidc: {
     enabled: true,
+    clientId: process.env.TELEGRAM_OIDC_CLIENT_ID!,
     clientSecret: process.env.TELEGRAM_OIDC_CLIENT_SECRET!, // from BotFather Web Login
     requestPhone: true, // get phone numbers, finally
   },
@@ -212,11 +213,10 @@ Don't need the Login Widget? Set `loginWidget: false` and skip the widget endpoi
 ```typescript
 // OIDC-only (no widget endpoints, no extra schema fields)
 telegram({
-  botToken: process.env.TELEGRAM_BOT_TOKEN!,
-  botUsername: "your_bot_username",
   loginWidget: false,
   oidc: {
     enabled: true,
+    clientId: process.env.TELEGRAM_OIDC_CLIENT_ID!,
     clientSecret: process.env.TELEGRAM_OIDC_CLIENT_SECRET!,
   },
 });
@@ -226,8 +226,8 @@ telegram({
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `botToken` | *required* | From @BotFather |
-| `botUsername` | *required* | Without the @ |
+| `botToken` | — | Required at runtime for Login Widget and Mini App HMAC verification; can provide the OIDC client ID fallback |
+| `botUsername` | — | Required only when rendering the Login Widget; without the @ |
 | `allowUserToLink` | `true` | Let users link Telegram to existing accounts |
 | `autoCreateUser` | `true` | Create user on first sign-in |
 | `maxAuthAge` | `86400` | Auth data TTL in seconds (replay attack prevention) |
@@ -239,6 +239,7 @@ telegram({
 | `miniApp.allowAutoSignin` | `true` | Allow auto sign-in from Mini Apps |
 | `miniApp.mapMiniAppDataToUser` | — | Custom Mini App user mapper |
 | `oidc.enabled` | `false` | Enable Telegram OIDC flow |
+| `oidc.clientId` | — | Client ID from BotFather Web Login; falls back to the bot ID in `botToken` |
 | `oidc.clientSecret` | — | Client Secret from BotFather Web Login (NOT the bot token) |
 | `oidc.scopes` | `["openid", "profile"]` | OIDC scopes to request |
 | `oidc.requestPhone` | `false` | Request phone number (adds `phone` scope) |
@@ -285,7 +286,7 @@ HMAC-SHA-256 verification on all auth data via Web Crypto API (`crypto.subtle`).
 
 Login Widget uses `SHA256(botToken)` as secret key. Mini Apps use `HMAC-SHA256("WebAppData", botToken)`. Different derivation paths, same level of paranoia.
 
-OIDC adds RS256 JWT verification via Telegram's JWKS endpoint, plus PKCE and state tokens for the OAuth flow. Keys are fetched and matched by `kid` — no hardcoded secrets, no trust-me-bro validation.
+OIDC verifies Telegram's documented `RS256`, `ES256`, and `EdDSA` JWT signatures via its JWKS endpoint, plus PKCE and state tokens for the OAuth flow. Keys must match both `kid` and `alg`. `ES256K` is intentionally rejected because the current `jose` runtime does not support it.
 
 Is it bulletproof? No. Is it better than storing passwords in plain text? Significantly.
 
@@ -306,6 +307,12 @@ Is it bulletproof? No. Is it better than storing passwords in plain text? Signif
 See [`examples/nextjs-app/`](./examples/nextjs-app) for a Next.js implementation covering all three auth flows: Login Widget, OIDC, Mini Apps, plus account linking/unlinking. Copy-paste-ready components and server/client setup. There's also a full test playground app in [`test/`](./test) if you want to see everything wired together with a real database.
 
 ## Migrating
+
+### To v2.0.0 (from v1.5.0)
+
+- Upgrade Better Auth to `>=1.6.22 <1.7.0`. Better Auth 1.7 is not supported by this release.
+- `botToken` and `botUsername` are now flow-aware. Missing values log setup warnings; the affected Widget, Mini App, or OIDC operation rejects if the credential is still missing when used.
+- OIDC-only setups can omit both bot fields when `oidc.clientId` and `oidc.clientSecret` are configured explicitly.
 
 ### To v1.5.0 (from v1.4.0)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 Telegram auth for [Better Auth](https://www.better-auth.com/). Login Widget, Mini Apps, the whole circus -- in one plugin that somehow works on every runtime.
 
-v1.1.0 | 173 tests | ESM + CJS | Web Crypto API | Works where `node:crypto` fears to tread
+ESM + CJS | Web Crypto API | Works where `node:crypto` fears to tread
 
 ---
 
@@ -59,7 +59,7 @@ That's it. The rest is in the [Installation Guide](./installation.md) for people
 ## Features
 
 - **Login Widget** -- callback and redirect modes, because one way to authenticate was never enough
-- **OIDC (OpenID Connect)** -- standard OAuth 2.0 with PKCE via `oauth.telegram.org`. Phone numbers, RS256 JWTs, grown-up auth. Telegram finally joined the federation
+- **OIDC (OpenID Connect)** -- standard OAuth 2.0 with PKCE via `oauth.telegram.org`. Phone numbers and JWKS-verified JWTs, without the legacy widget callback
 - **Mini Apps** -- auto-signin, manual signin, initData validation. Enable it, forget it works
 - **Link/unlink** -- attach Telegram to existing accounts, detach when you inevitably change your mind
 - **HMAC-SHA-256 via Web Crypto API** (`crypto.subtle`) -- runs on Node, Bun, Cloudflare Workers, edge runtimes, presumably a toaster
@@ -91,7 +91,7 @@ That's it. The rest is in the [Installation Guide](./installation.md) for people
 ## Requirements
 
 - Node.js >= 22 (or Bun, or any runtime with Web Crypto API)
-- `better-auth@^1.5.0`
+- `better-auth@>=1.6.22 <1.7.0`
 - HTTPS (Telegram insists, and honestly, so should you)
 - Public domain (use ngrok for local dev)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -59,7 +59,7 @@ That's it. The rest is in the [Installation Guide](./installation.md) for people
 ## Features
 
 - **Login Widget** -- callback and redirect modes, because one way to authenticate was never enough
-- **OIDC (OpenID Connect)** -- standard OAuth 2.0 with PKCE via `oauth.telegram.org`. Phone numbers and JWKS-verified JWTs, without the legacy widget callback
+- **OIDC (OpenID Connect)** -- standard OAuth 2.0 with PKCE via `oauth.telegram.org`. Phone numbers when the `phone` scope is requested, plus JWKS-verified JWTs, without the legacy widget callback
 - **Mini Apps** -- auto-signin, manual signin, initData validation. Enable it, forget it works
 - **Link/unlink** -- attach Telegram to existing accounts, detach when you inevitably change your mind
 - **HMAC-SHA-256 via Web Crypto API** (`crypto.subtle`) -- runs on Node, Bun, Cloudflare Workers, edge runtimes, presumably a toaster

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -19,7 +19,7 @@ Everything you never knew you needed to know about `better-auth-telegram`, laid 
 
 ### `telegram(options)`
 
-The main server plugin function. Returns a `BetterAuthPlugin` object. If you forget `botToken`, it throws immediately -- no silent failures here.
+The main server plugin function. Returns a `BetterAuthPlugin` object. Credentials are checked per enabled flow: missing values warn during setup and the affected request fails closed at runtime.
 
 ```typescript
 import { telegram } from "better-auth-telegram";
@@ -35,8 +35,9 @@ const plugin = telegram({
 
 | Option | Type | Default | Description |
 |---|---|---|---|
-| `botToken` | `string` | **required** | Bot token from @BotFather. The plugin throws if missing. |
-| `botUsername` | `string` | **required** | Bot username without the `@`. Also throws if missing. |
+| `botToken` | `string` | `undefined` | Required at runtime for enabled Login Widget and Mini App flows. Can provide the OIDC client ID fallback. |
+| `botUsername` | `string` | `undefined` | Required when rendering the Login Widget. Bot username without the `@`. |
+| `loginWidget` | `boolean` | `true` | Enable Login Widget endpoints. Telegram schema fields remain enabled separately when Mini App support is active. |
 | `allowUserToLink` | `boolean` | `true` | Allow authenticated users to link their Telegram account. |
 | `autoCreateUser` | `boolean` | `true` | Auto-create a user when a new Telegram user signs in. |
 | `maxAuthAge` | `number` | `86400` (24 hours) | Maximum age of `auth_date` in seconds. Prevents replay attacks. |
@@ -59,8 +60,10 @@ const plugin = telegram({
 | Option | Type | Default | Description |
 |---|---|---|---|
 | `oidc.enabled` | `boolean` | `false` | Enable Telegram OIDC. Injects `telegram-oidc` social provider via the `init` hook. |
+| `oidc.clientId` | `string` | bot ID from `botToken` | Client ID from BotFather Web Login. Required when `botToken` is omitted. |
+| `oidc.clientSecret` | `string` | `botToken` fallback | Client Secret from BotFather Web Login. Configure this explicitly for Telegram OIDC. |
 | `oidc.scopes` | `string[]` | `["openid", "profile"]` | OIDC scopes to request. |
-| `oidc.requestPhone` | `boolean` | `false` | Add `phone` scope. Populates `telegramPhoneNumber` on the user record. |
+| `oidc.requestPhone` | `boolean` | `false` | Add `phone` scope. Persist `claims.phone_number` through `mapOIDCProfileToUser` if needed. |
 | `oidc.requestBotAccess` | `boolean` | `false` | Add `telegram:bot_access` scope. |
 | `oidc.mapOIDCProfileToUser` | `(claims: TelegramOIDCClaims) => UserData` | uses `name` + `picture` from claims | Custom mapping from OIDC claims. |
 
@@ -309,7 +312,7 @@ if (result.data?.valid) {
 
 #### `autoSignInFromMiniApp(fetchOptions?)`
 
-The lazy developer's dream. Automatically grabs `initData` from `window.Telegram.WebApp.initData` and signs in. Only works inside a Telegram Mini App -- throws if you try it in a regular browser.
+Automatically grabs `initData` from `window.Telegram.WebApp.initData`, falling back to the `tgWebAppData` URL-fragment launch parameter, and signs in. Throws when neither source is available.
 
 ```typescript
 try {
@@ -377,8 +380,9 @@ Server plugin configuration. See the [Server Plugin](#server-plugin) section for
 interface TelegramPluginOptions {
   allowUserToLink?: boolean;     // default: true
   autoCreateUser?: boolean;      // default: true
-  botToken: string;              // required
-  botUsername: string;            // required
+  botToken?: string;             // Widget/Mini App runtime credential
+  botUsername?: string;          // required when rendering the Widget
+  loginWidget?: boolean;         // default: true
   mapTelegramDataToUser?: (data: TelegramAuthData) => {
     name?: string;
     email?: string;
@@ -408,6 +412,8 @@ Configuration for the OIDC authentication flow.
 
 ```typescript
 interface TelegramOIDCOptions {
+  clientId?: string;             // BotFather Web Login; falls back to bot ID
+  clientSecret?: string;         // BotFather Web Login; configure explicitly
   enabled?: boolean;             // default: false
   scopes?: string[];             // default: ["openid", "profile"]
   requestPhone?: boolean;        // default: false — adds "phone" scope
@@ -427,8 +433,11 @@ JWT ID token claims from Telegram OIDC. What you get back after the OAuth dance.
 
 ```typescript
 interface TelegramOIDCClaims {
-  aud: string;                   // bot ID (client_id)
+  aud: string;                   // configured OIDC client ID
   exp: number;                   // expiration timestamp
+  family_name?: string;
+  given_name?: string;
+  id?: number;                   // Telegram numeric user ID when supplied
   iat: number;                   // issued at timestamp
   iss: string;                   // "https://oauth.telegram.org"
   sub: string;                   // Telegram user ID
@@ -436,6 +445,7 @@ interface TelegramOIDCClaims {
   preferred_username?: string;   // Telegram username
   picture?: string;              // profile photo URL
   phone_number?: string;         // only with "phone" scope
+  phone_number_verified?: boolean;
 }
 ```
 
@@ -717,7 +727,7 @@ Validate Mini App `initData` without creating a session. Only available when `mi
 OIDC doesn't register custom endpoints. It injects a `telegram-oidc` social provider via the `init` hook, and Better Auth's built-in routes handle the rest:
 
 - **`POST /sign-in/social`** with `{ provider: "telegram-oidc", callbackURL: "/dashboard" }` — initiates the OAuth 2.0 Authorization Code flow with PKCE
-- **`GET /callback/telegram-oidc`** — handles the OAuth callback, verifies the RS256 JWT ID token against Telegram's JWKS endpoint, creates/links user, sets session
+- **`GET /callback/telegram-oidc`** — handles the OAuth callback, verifies the JWT ID token against Telegram's JWKS endpoint using `RS256`, `ES256`, or `EdDSA`, creates/links user, sets session
 
 Zero custom endpoints. Delegation at its finest.
 
@@ -794,7 +804,7 @@ The plugin extends Better Auth's database schema with these fields. User fields 
 |---|---|---|---|---|---|
 | `telegramId` | `string` | `false` | `false` | `false` | |
 | `telegramUsername` | `string` | `false` | `false` | `false` | |
-| `telegramPhoneNumber` | `string` | `false` | `false` | `false` | Populated via OIDC with `phone` scope |
+| `telegramPhoneNumber` | `string` | `false` | `false` | `false` | Available for custom OIDC profile mapping when this schema field is enabled |
 
 ### Account Table
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -131,7 +131,7 @@ telegram({
 |--------|------|---------|-------------|
 | `enabled` | `boolean` | `false` | Turn on Telegram OIDC. Injects a `telegram-oidc` provider into Better Auth's social login system via the `init` hook. |
 | `clientId` | `string` | bot ID from `botToken` | Client ID from BotFather Web Login. Required when `botToken` is omitted. |
-| `clientSecret` | `string` | `botToken` fallback | Client Secret from BotFather Web Login. Configure it explicitly; a bot token is not a valid OIDC client secret. |
+| `clientSecret` | `string` | `botToken` compatibility fallback | Client Secret from BotFather Web Login. The bot-token fallback is retained for backward compatibility, but Telegram's official OIDC flow requires the Web Login Client Secret. |
 | `scopes` | `string[]` | `["openid", "profile"]` | OIDC scopes to request. `openid` is always included regardless. |
 | `requestPhone` | `boolean` | `false` | Add the `phone` scope. Read `claims.phone_number` in `mapOIDCProfileToUser` to persist it. |
 | `requestBotAccess` | `boolean` | `false` | Add the `telegram:bot_access` scope. Lets your bot send messages to the user. |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -4,9 +4,9 @@ Everything you can tweak, nothing you can't. No database adapters, no session ph
 
 ## Server Configuration
 
-### The Bare Minimum
+### Login Widget Minimum
 
-Two strings. That's it. Revolutionary.
+The default enables the Login Widget, so it needs the bot token and username when that flow is used.
 
 ```typescript
 import { betterAuth } from "better-auth";
@@ -29,8 +29,8 @@ Every option, every default, no surprises (for once).
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `botToken` | `string` | **required** | Bot token from @BotFather. The one secret you actually need to keep secret. |
-| `botUsername` | `string` | **required** | Bot username without the `@`. Yes, without it. |
+| `botToken` | `string` | `undefined` | Required at runtime by enabled Login Widget and Mini App flows for HMAC verification. OIDC can use an explicit `oidc.clientId` and `oidc.clientSecret` instead. |
+| `botUsername` | `string` | `undefined` | Required only when the Login Widget is rendered. Bot username without the `@`. |
 | `allowUserToLink` | `boolean` | `true` | Let users link Telegram to an existing account. |
 | `autoCreateUser` | `boolean` | `true` | Auto-create a user on first sign-in. Set to `false` if you enjoy gatekeeping. |
 | `maxAuthAge` | `number` | `86400` | How many seconds old the auth data can be before we reject it. 86400 = 24 hours. Prevents replay attacks from time travellers. |
@@ -84,7 +84,6 @@ For when your app lives inside Telegram itself. Disabled by default.
 ```typescript
 telegram({
   botToken: process.env.TELEGRAM_BOT_TOKEN!,
-  botUsername: process.env.TELEGRAM_BOT_USERNAME!,
   miniApp: {
     enabled: true,
     validateInitData: true,
@@ -107,20 +106,22 @@ telegram({
 
 ### OIDC Configuration
 
-Standard OAuth 2.0 Authorization Code flow with PKCE via `oauth.telegram.org`. Phone numbers, RS256 JWT verification, proper grown-up auth. Disabled by default because not everyone needs the full federation experience.
+Standard OAuth 2.0 Authorization Code flow with PKCE via `oauth.telegram.org`. Phone numbers and JWKS-verified JWTs without the legacy Widget callback. Disabled by default.
 
 ```typescript
 telegram({
-  botToken: process.env.TELEGRAM_BOT_TOKEN!,
-  botUsername: process.env.TELEGRAM_BOT_USERNAME!,
+  loginWidget: false,
   oidc: {
     enabled: true,
+    clientId: process.env.TELEGRAM_OIDC_CLIENT_ID!,
+    clientSecret: process.env.TELEGRAM_OIDC_CLIENT_SECRET!,
     requestPhone: true,        // get phone numbers via the `phone` scope
     requestBotAccess: false,   // request bot access via `telegram:bot_access` scope
     scopes: ["openid", "profile"],  // default scopes
     mapOIDCProfileToUser: (claims) => ({
       name: `${claims.name}`,
       image: claims.picture,
+      telegramPhoneNumber: claims.phone_number,
     }),
   },
 })
@@ -129,12 +130,16 @@ telegram({
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `enabled` | `boolean` | `false` | Turn on Telegram OIDC. Injects a `telegram-oidc` provider into Better Auth's social login system via the `init` hook. |
+| `clientId` | `string` | bot ID from `botToken` | Client ID from BotFather Web Login. Required when `botToken` is omitted. |
+| `clientSecret` | `string` | `botToken` fallback | Client Secret from BotFather Web Login. Configure it explicitly; a bot token is not a valid OIDC client secret. |
 | `scopes` | `string[]` | `["openid", "profile"]` | OIDC scopes to request. `openid` is always included regardless. |
-| `requestPhone` | `boolean` | `false` | Add the `phone` scope. Gets you `telegramPhoneNumber` on the user record. The Login Widget never could. |
+| `requestPhone` | `boolean` | `false` | Add the `phone` scope. Read `claims.phone_number` in `mapOIDCProfileToUser` to persist it. |
 | `requestBotAccess` | `boolean` | `false` | Add the `telegram:bot_access` scope. Lets your bot send messages to the user. |
-| `mapOIDCProfileToUser` | `function` | uses `name` + `picture` from claims | Custom mapping from `TelegramOIDCClaims` to your user object. Gets `sub`, `name`, `preferred_username`, `picture`, `phone_number`. |
+| `mapOIDCProfileToUser` | `function` | uses `name` + `picture` from claims | Custom mapping from `TelegramOIDCClaims` to your user object. Claims are optional except for the standard token fields; see the API reference. |
 
 OIDC uses Better Auth's built-in social login routes — no custom endpoints. The plugin injects a `telegram-oidc` provider via the `init` hook and Better Auth handles `POST /sign-in/social` and `GET /callback/telegram-oidc` automatically.
+
+Missing flow credentials produce setup warnings instead of aborting application startup. The corresponding request still fails closed if the credential is missing when the flow is used.
 
 ### Test Server Mode
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -5,7 +5,7 @@ You want Telegram auth in your app. Bold choice. Let's get it done without a twe
 ## Prerequisites
 
 - Node.js >= 22
-- A [Better Auth](https://www.better-auth.com/) project (v1.5.0+)
+- A [Better Auth](https://www.better-auth.com/) project (`>=1.6.22 <1.7.0`)
 - A Telegram account (shocking, I know)
 
 ## Install
@@ -80,7 +80,7 @@ No secret handshakes required. The client fetches bot config from your server au
 
 ## Database Schema
 
-The plugin adds fields to **both** the `user` and `account` tables:
+When Login Widget or Mini App support is enabled, the plugin adds fields to **both** the `user` and `account` tables. OIDC-only setups with `loginWidget: false` do not declare these fields; add any OIDC profile fields you want to persist to your own user schema.
 
 **User table:**
 
@@ -88,7 +88,7 @@ The plugin adds fields to **both** the `user` and `account` tables:
 | --------------------- | -------- | -------- | ----- |
 | `telegramId`          | `string` | Yes      | |
 | `telegramUsername`    | `string` | Yes      | |
-| `telegramPhoneNumber` | `string` | Yes      | Populated via OIDC with `phone` scope |
+| `telegramPhoneNumber` | `string` | Yes      | Available for custom OIDC profile mapping when the `phone` scope is requested |
 
 **Account table:**
 
@@ -106,7 +106,7 @@ model User {
   // ... existing fields
   telegramId          String?
   telegramUsername     String?
-  telegramPhoneNumber  String?  // only needed if using OIDC with phone scope
+  telegramPhoneNumber  String?  // map claims.phone_number here if requested
 }
 
 model Account {

--- a/docs/miniapps.md
+++ b/docs/miniapps.md
@@ -2,7 +2,7 @@
 
 Your web app, living inside Telegram. No login popups, no OAuth dances, no "please verify your email." The user opened your Mini App — they're already Telegram. Act accordingly.
 
-Works with `better-auth-telegram` v0.4.0+ and `better-auth@^1.5.0`.
+Requires `better-auth@>=1.6.22 <1.7.0`.
 
 ## Mini Apps vs Login Widget
 
@@ -126,7 +126,7 @@ const result = await authClient.autoSignInFromMiniApp();
 // result.data?.user — your user, authenticated, ready to go
 ```
 
-`autoSignInFromMiniApp()` grabs `window.Telegram.WebApp.initData` automatically, sends it to `/telegram/miniapp/signin`, sets the session cookie, done. If it's not running inside Telegram, it throws.
+`autoSignInFromMiniApp()` prefers `window.Telegram.WebApp.initData` and falls back to the `tgWebAppData` launch parameter in `window.location.hash`. It sends the raw value to `/telegram/miniapp/signin`, where the server verifies it before creating a session. If neither source exists, it throws.
 
 ### 4. Manual Sign-in (More Control)
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -119,21 +119,22 @@ The plugin uses Authorization Code flow with Proof Key for Code Exchange (PKCE).
 
 All of this is handled by Better Auth's social login system. You don't configure any of it.
 
-### RS256 JWT Verification
+### OIDC JWT Verification
 
-ID tokens from Telegram are signed with RS256 (RSA + SHA-256). The plugin verifies them against Telegram's JWKS endpoint (`oauth.telegram.org/.well-known/jwks.json`):
+Telegram currently documents `RS256`, `ES256`, `EdDSA`, and `ES256K` signing algorithms. The plugin accepts `RS256`, `ES256`, and `EdDSA`, which are supported by the current `jose` runtime, and rejects `ES256K`. It verifies accepted tokens against Telegram's JWKS endpoint (`oauth.telegram.org/.well-known/jwks.json`):
 
-1. Decode the JWT header to get the `kid` (Key ID)
-2. Fetch the public key set from Telegram's JWKS endpoint
-3. Match by `kid`, verify the signature
-4. Validate `iss` (issuer), `aud` (audience = your bot ID), and `exp` (expiration)
+1. Decode the JWT header to get `kid` (Key ID) and `alg`
+2. Reject algorithms outside the explicit allowlist
+3. Fetch the public key set from Telegram's JWKS endpoint
+4. Match the key by both `kid` and `alg`, then verify the signature
+5. Validate `iss` (issuer), `aud` (audience = your client ID), and `exp` (expiration)
 
 Keys are fetched per verification — no caching means no stale-key vulnerabilities. The `jose` library handles the heavy lifting.
 
 ### What This Prevents
 
-- **Token forgery** — RS256 signatures require Telegram's private key. Good luck with that.
-- **Token replay** — `exp` claim enforces expiration. `aud` ensures the token was meant for your bot.
+- **Token forgery** — supported signatures require Telegram's private key. Good luck with that.
+- **Token replay** — `exp` claim enforces expiration. `aud` ensures the token was meant for your OIDC client.
 - **Authorization code interception** — PKCE makes stolen auth codes useless without the original `code_verifier`.
 - **CSRF on callback** — state parameter binds the callback to the session that initiated the flow.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -262,7 +262,7 @@ The `telegram-oidc` provider isn't being injected. Check:
 
 The OAuth callback failed. Usual suspects:
 
-1. **Bot token mismatch** — the bot ID (first part of the token, before the `:`) is used as the `client_id`. If the token is wrong, Telegram rejects the token exchange.
+1. **OIDC credentials mismatch** — use the Client ID and Client Secret from BotFather Web Login. The bot ID is only a fallback for `client_id`; the bot token is not a valid OIDC client secret.
 2. **Callback URL not configured** — Better Auth needs to know where your callback lives. Check your `BETTER_AUTH_URL` or `baseURL` configuration.
 3. **JWKS fetch failed** — the plugin fetches public keys from `oauth.telegram.org/.well-known/jwks.json`. If your server can't reach that URL (firewall, DNS, corporate proxy), JWT verification fails silently.
 
@@ -274,10 +274,13 @@ You need `requestPhone: true` in your OIDC config **and** the user needs to cons
 oidc: {
   enabled: true,
   requestPhone: true,  // this one
+  mapOIDCProfileToUser: (claims) => ({
+    telegramPhoneNumber: claims.phone_number,
+  }),
 }
 ```
 
-Also make sure your `user` table has the `telegramPhoneNumber` column. The plugin won't yell at you if it's missing — it'll just silently not store it.
+`requestPhone` exposes `phone_number` to the mapper; it does not persist that claim automatically. Define the destination field in your user schema and return it from `mapOIDCProfileToUser`. The optional `phone_number_verified` claim tells you whether Telegram marked the number as verified.
 
 ## Session Problems
 
@@ -330,8 +333,8 @@ Every error this plugin can throw, mapped to what actually went wrong:
 
 | Error Message | HTTP Status | What It Means |
 |---|---|---|
-| `Telegram plugin: botToken is required` | N/A (thrown at init) | You didn't pass `botToken` to the plugin config. It won't even start. |
-| `Telegram plugin: botUsername is required` | N/A (thrown at init) | You didn't pass `botUsername` to the plugin config. Also won't start. |
+| `Telegram plugin: botToken is required` | 500 | An enabled Login Widget or Mini App request reached the server without a configured `botToken`. Setup also logs a warning. |
+| `Telegram plugin: botUsername is required` | Client error | The client tried to render the Login Widget without a configured username. Setup also logs a warning. |
 | `Invalid Telegram auth data` | 400 | Request body missing required fields (`id`, `first_name`, `auth_date`, `hash`). |
 | `Invalid Telegram authentication` | 401 | HMAC check failed. Wrong token, expired data, or tampered payload. |
 | `User not found and auto-create is disabled` | 404 | `autoCreateUser` is `false` and no existing account matches. |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -195,11 +195,15 @@ Enable on server:
 
 ```typescript
 telegram({
-  botToken: process.env.TELEGRAM_BOT_TOKEN!,
-  botUsername: "your_bot_username",
+  loginWidget: false,
   oidc: {
     enabled: true,
+    clientId: process.env.TELEGRAM_OIDC_CLIENT_ID!,
+    clientSecret: process.env.TELEGRAM_OIDC_CLIENT_SECRET!,
     requestPhone: true,  // phone numbers -- the Login Widget's biggest regret
+    mapOIDCProfileToUser: (claims) => ({
+      telegramPhoneNumber: claims.phone_number,
+    }),
   },
 });
 ```
@@ -216,15 +220,13 @@ That's it. Better Auth's social login system handles the PKCE, state tokens, JWT
 
 ### OIDC + Phone Numbers
 
-The `phone` scope gives you what the Login Widget never could. When `requestPhone: true`, the user's phone number lands in `telegramPhoneNumber` on the user record after OIDC sign-in.
+The `phone` scope gives you what the Login Widget never could. With `requestPhone: true`, Telegram can return `phone_number` and `phone_number_verified` claims. The plugin exposes them to `mapOIDCProfileToUser`; persist the value in a field defined by your user schema.
 
 ```typescript
-// After OIDC sign-in, your user record has:
+// With telegramPhoneNumber defined in your user schema and mapped above:
 {
   name: "John Doe",
-  telegramId: "123456789",
-  telegramUsername: "johndoe",
-  telegramPhoneNumber: "+1234567890",  // only via OIDC with phone scope
+  telegramPhoneNumber: "+1234567890",
 }
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,31 +1,31 @@
 {
   "name": "better-auth-telegram",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "better-auth-telegram",
-      "version": "1.1.0",
+      "version": "2.0.0",
       "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "2.4.4",
-        "@types/node": "^25.3.0",
-        "@vitest/coverage-v8": "4.0.18",
-        "@vitest/ui": "^4.0.18",
-        "better-auth": "1.5.0",
-        "happy-dom": "20.7.0",
+        "@types/node": "^24.13.3",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "^4.1.10",
+        "better-auth": "1.6.25",
+        "happy-dom": "20.11.1",
         "lint-staged": "16.2.7",
         "tsup": "8.5.1",
         "typescript": "5.9.3",
         "ultracite": "7.2.3",
-        "vitest": "4.0.18"
+        "vitest": "4.1.10"
       },
       "engines": {
         "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "better-auth": "^1.5.0"
+        "better-auth": ">=1.6.22 <1.7.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -89,119 +89,146 @@
       }
     },
     "node_modules/@better-auth/core": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@better-auth/core/-/core-1.5.0.tgz",
-      "integrity": "sha512-nDPmW7I9VGRACEei31fHaZxGwD/yICraDllZ/f25jbWXYaxDaW88RuH1ZhbOUKmGJlZtDxcjN1+YmcVIc1ioNw==",
+      "version": "1.6.25",
+      "resolved": "https://registry.npmjs.org/@better-auth/core/-/core-1.6.25.tgz",
+      "integrity": "sha512-lMTlhtwyK4NpY9kPF+2rQCRKYpg136d3gM2xl8esxT1PjJx5Nh5YwZvxcYCIjDuO759sx6TCloJTuwcZGG6ZBw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.39.0",
         "@standard-schema/spec": "^1.1.0",
         "zod": "^4.3.6"
       },
       "peerDependencies": {
-        "@better-auth/utils": "0.3.1",
-        "@better-fetch/fetch": "1.1.21",
+        "@better-auth/utils": "0.4.2",
+        "@better-fetch/fetch": "1.3.1",
         "@cloudflare/workers-types": ">=4",
-        "better-call": "1.3.2",
+        "@opentelemetry/api": "^1.9.0",
+        "better-call": "1.3.7",
         "jose": "^6.1.0",
-        "kysely": "^0.28.5",
+        "kysely": "^0.28.5 || ^0.29.0",
         "nanostores": "^1.0.1"
       },
       "peerDependenciesMeta": {
         "@cloudflare/workers-types": {
           "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
         }
       }
     },
     "node_modules/@better-auth/drizzle-adapter": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@better-auth/drizzle-adapter/-/drizzle-adapter-1.5.0.tgz",
-      "integrity": "sha512-qNKAoe+ViiHznipkoOCLo3pDvQo4/6mYbCwnfo2mNbjjopqIn0c3IKW2t+e/Mg4Y18PJcEFeOiIRoY9pUyTtAg==",
+      "version": "1.6.25",
+      "resolved": "https://registry.npmjs.org/@better-auth/drizzle-adapter/-/drizzle-adapter-1.6.25.tgz",
+      "integrity": "sha512-ru/DeKjFPQUVeKkxF/ScazmPqIY7lwfkAV5Yt4j24wmn1Y8vFwoiPRnHgXUeZqBs10+nubaRwEqLF39CP6EhRw==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "@better-auth/core": "1.5.0",
-        "@better-auth/utils": "^0.3.0",
-        "drizzle-orm": ">=0.41.0"
+        "@better-auth/core": "^1.6.25",
+        "@better-auth/utils": "0.4.2",
+        "drizzle-orm": "^0.45.2"
+      },
+      "peerDependenciesMeta": {
+        "drizzle-orm": {
+          "optional": true
+        }
       }
     },
     "node_modules/@better-auth/kysely-adapter": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@better-auth/kysely-adapter/-/kysely-adapter-1.5.0.tgz",
-      "integrity": "sha512-dSC7yzF58YMrn39srrX/LwMLjd11PtTORjn3RKFwuzVCS07mqMZpPkk3XbQW/ZXxXbdUByrgYQo9z9zFCF37RQ==",
+      "version": "1.6.25",
+      "resolved": "https://registry.npmjs.org/@better-auth/kysely-adapter/-/kysely-adapter-1.6.25.tgz",
+      "integrity": "sha512-zxiePhtN1YClS1irKYPVwWfN6kYp+QoYlz1hdQUOj8hXyo2aE/ny4RNAb6v332b0+U6Vu88EhYITRPdmvCo6uA==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "@better-auth/core": "1.5.0",
-        "@better-auth/utils": "^0.3.0",
-        "kysely": "^0.27.0 || ^0.28.0"
+        "@better-auth/core": "^1.6.25",
+        "@better-auth/utils": "0.4.2",
+        "kysely": "^0.28.17 || ^0.29.0"
+      },
+      "peerDependenciesMeta": {
+        "kysely": {
+          "optional": true
+        }
       }
     },
     "node_modules/@better-auth/memory-adapter": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@better-auth/memory-adapter/-/memory-adapter-1.5.0.tgz",
-      "integrity": "sha512-fp0OtEpWi4RgfxrhhAI8tKW8yHTHx49V12UW1XyuUKrEK0jbu+CzVJSzoMkv/q3fJfjGqDe/vNvWtVBtpIRpQw==",
+      "version": "1.6.25",
+      "resolved": "https://registry.npmjs.org/@better-auth/memory-adapter/-/memory-adapter-1.6.25.tgz",
+      "integrity": "sha512-GhEzTumc8yfTz+OZ6pMg06BA49xob49x1bX+1mEl/FStDJoSF+6mTfI5M2ytFxaiN89336/aUjkW8u+qRyLexw==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "@better-auth/core": "1.5.0",
-        "@better-auth/utils": "^0.3.0"
+        "@better-auth/core": "^1.6.25",
+        "@better-auth/utils": "0.4.2"
       }
     },
     "node_modules/@better-auth/mongo-adapter": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@better-auth/mongo-adapter/-/mongo-adapter-1.5.0.tgz",
-      "integrity": "sha512-qI+MiewH6kzUbNkKBX4fdhPl1MkIXq8V7v3TEt/DLAHC4/QxmPqhxQHEDeZBxO+NH8+Zekr2sQzKRRFfbaQKbw==",
+      "version": "1.6.25",
+      "resolved": "https://registry.npmjs.org/@better-auth/mongo-adapter/-/mongo-adapter-1.6.25.tgz",
+      "integrity": "sha512-ZtMmjcOdXR2Ziqx5y8ptTOaNpe0snNfALbBUPXJsgeyeRkDJDYzyLZ8MpuvNBTNllNeIFDbiXWAK5k+pEBZrUQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "@better-auth/core": "1.5.0",
-        "@better-auth/utils": "^0.3.0",
+        "@better-auth/core": "^1.6.25",
+        "@better-auth/utils": "0.4.2",
         "mongodb": "^6.0.0 || ^7.0.0"
+      },
+      "peerDependenciesMeta": {
+        "mongodb": {
+          "optional": true
+        }
       }
     },
     "node_modules/@better-auth/prisma-adapter": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@better-auth/prisma-adapter/-/prisma-adapter-1.5.0.tgz",
-      "integrity": "sha512-Sga8DTeCCsamGZ7/54kH0HKlrCrgW4EApadAgsufsIcRqHteeKC5rNCLIppfyRa/xJxm5xImUeks6Nvz3zL1tw==",
+      "version": "1.6.25",
+      "resolved": "https://registry.npmjs.org/@better-auth/prisma-adapter/-/prisma-adapter-1.6.25.tgz",
+      "integrity": "sha512-ym7B6Iqcry+/4aQnYpFwqP/GBIiXvjrm/5B6+0qmx8mkTY/apHFTpHuGzUYYNf4vPTtzF3eYY2+s2GOsomKaRg==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "@prisma/client": "^7.4.1"
-      },
       "peerDependencies": {
-        "@better-auth/core": "1.5.0",
-        "@better-auth/utils": "^0.3.0",
+        "@better-auth/core": "^1.6.25",
+        "@better-auth/utils": "0.4.2",
         "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0",
         "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@prisma/client": {
+          "optional": true
+        },
+        "prisma": {
+          "optional": true
+        }
       }
     },
     "node_modules/@better-auth/telemetry": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@better-auth/telemetry/-/telemetry-1.5.0.tgz",
-      "integrity": "sha512-/6ThGSnGPVTR4A/6F8kv65UomDHtM24y2yRZuJfWYbqkve0jn8+WVsxOfQN9bx7J16zIvYw5hJAYCwxoj20BTQ==",
+      "version": "1.6.25",
+      "resolved": "https://registry.npmjs.org/@better-auth/telemetry/-/telemetry-1.6.25.tgz",
+      "integrity": "sha512-2ZfC9lp7tU6Jw/q2Lz/bKfQqGMdMwc/IQDTYdBhvtGi24qInYVnhp2ZCW57hHM9j+fq1ULOtxgg6M3T1LEaihw==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "@better-auth/utils": "0.3.1",
-        "@better-fetch/fetch": "1.1.21"
-      },
       "peerDependencies": {
-        "@better-auth/core": "1.5.0"
+        "@better-auth/core": "^1.6.25",
+        "@better-auth/utils": "0.4.2",
+        "@better-fetch/fetch": "1.3.1"
       }
     },
     "node_modules/@better-auth/utils": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@better-auth/utils/-/utils-0.3.1.tgz",
-      "integrity": "sha512-+CGp4UmZSUrHHnpHhLPYu6cV+wSUSvVbZbNykxhUDocpVNTo9uFFxw/NqJlh1iC4wQ9HKKWGCKuZ5wUgS0v6Kg==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@better-auth/utils/-/utils-0.4.2.tgz",
+      "integrity": "sha512-AUxrvu+HaaODsUyzDxFgwd/8RZ1yZaYo42LXKSrU2oGgR38pS1ij8nqQKNgtTWoYGpNevNXtCfgTy6loHveW9A==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^2.0.1"
+      }
     },
     "node_modules/@better-fetch/fetch": {
-      "version": "1.1.21",
-      "resolved": "https://registry.npmjs.org/@better-fetch/fetch/-/fetch-1.1.21.tgz",
-      "integrity": "sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A==",
-      "dev": true
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@better-fetch/fetch/-/fetch-1.3.1.tgz",
+      "integrity": "sha512-ABkD1WhyfPZprKRQI3bhATjeiFuNWC9PXhfGWqL+sg/gKrM977oFrYkdb4msM3hgUGonr7KlOsOFT5TU2rht9g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@biomejs/biome": {
       "version": "2.4.4",
@@ -378,47 +405,6 @@
         "node": ">=14.21.3"
       }
     },
-    "node_modules/@chevrotain/cst-dts-gen": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-10.5.0.tgz",
-      "integrity": "sha512-lhmC/FyqQ2o7pGK4Om+hzuDrm9rhFYIJ/AXoQBeongmn870Xeb0L6oGEiuR8nohFNL5sMaQEJWCxr1oIVIVXrw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@chevrotain/gast": "10.5.0",
-        "@chevrotain/types": "10.5.0",
-        "lodash": "4.17.21"
-      }
-    },
-    "node_modules/@chevrotain/gast": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-10.5.0.tgz",
-      "integrity": "sha512-pXdMJ9XeDAbgOWKuD1Fldz4ieCs6+nLNmyVhe2gZVqoO7v8HXuHYs5OV2EzUtbuai37TlOAQHrTDvxMnvMJz3A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@chevrotain/types": "10.5.0",
-        "lodash": "4.17.21"
-      }
-    },
-    "node_modules/@chevrotain/types": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-10.5.0.tgz",
-      "integrity": "sha512-f1MAia0x/pAVPWH/T73BJVyO2XU5tI4/iE7cnxb7tqdNTNhQI3Uq3XkqcoteTmD4t1aM0LbHCJOhgIDn07kl2A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true
-    },
-    "node_modules/@chevrotain/utils": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-10.5.0.tgz",
-      "integrity": "sha512-hBzuU5+JjB2cqNZyszkDHZgOSrUUT8V3dhgRl8Q9Gp6dAj/H5+KILGjbhDpc3Iy9qmqlm/akuOI2ut9VUtzJxQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true
-    },
     "node_modules/@clack/core": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@clack/core/-/core-1.0.1.tgz",
@@ -442,37 +428,41 @@
         "sisteransi": "^1.0.5"
       }
     },
-    "node_modules/@electric-sql/pglite": {
-      "version": "0.3.15",
-      "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.3.15.tgz",
-      "integrity": "sha512-Cj++n1Mekf9ETfdc16TlDi+cDDQF0W7EcbyRHYOAeZdsAe8M/FJg18itDTSwyHfar2WIezawM9o0EKaRGVKygQ==",
+    "node_modules/@emnapi/core": {
+      "version": "2.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-2.0.0-alpha.3.tgz",
+      "integrity": "sha512-AZypUeJ/yByuxyS7BlSNRDOMLMlROYtjYdIAuBmJssVz1UJDSeYxLrdizhXCFYhedC5bqd/ASy8EuNXbVVXp9g==",
       "dev": true,
-      "license": "Apache-2.0",
-      "peer": true
-    },
-    "node_modules/@electric-sql/pglite-socket": {
-      "version": "0.0.20",
-      "resolved": "https://registry.npmjs.org/@electric-sql/pglite-socket/-/pglite-socket-0.0.20.tgz",
-      "integrity": "sha512-J5nLGsicnD9wJHnno9r+DGxfcZWh+YJMCe0q/aCgtG6XOm9Z7fKeite8IZSNXgZeGltSigM9U/vAWZQWdgcSFg==",
-      "dev": true,
-      "license": "Apache-2.0",
+      "license": "MIT",
+      "optional": true,
       "peer": true,
-      "bin": {
-        "pglite-server": "dist/scripts/server.js"
-      },
-      "peerDependencies": {
-        "@electric-sql/pglite": "0.3.15"
+      "dependencies": {
+        "@emnapi/wasi-threads": "2.0.1",
+        "tslib": "^2.4.0"
       }
     },
-    "node_modules/@electric-sql/pglite-tools": {
-      "version": "0.2.20",
-      "resolved": "https://registry.npmjs.org/@electric-sql/pglite-tools/-/pglite-tools-0.2.20.tgz",
-      "integrity": "sha512-BK50ZnYa3IG7ztXhtgYf0Q7zijV32Iw1cYS8C+ThdQlwx12V5VZ9KRJ42y82Hyb4PkTxZQklVQA9JHyUlex33A==",
+    "node_modules/@emnapi/runtime": {
+      "version": "2.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-2.0.0-alpha.3.tgz",
+      "integrity": "sha512-hFPAhMUjJD9BSyCANEISPOogeXC9Zo9ZQl7L6vKnaVsMkCtzznaW/naYypeyl0Gv5rYfWYsZbpixTMpjDJzQeA==",
       "dev": true,
-      "license": "Apache-2.0",
+      "license": "MIT",
+      "optional": true,
       "peer": true,
-      "peerDependencies": {
-        "@electric-sql/pglite": "0.3.15"
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-2.0.1.tgz",
+      "integrity": "sha512-9DsSk+o5NBX0CCJT8s0EROGSGxjR/tKu6aBTaVyq+SjAEQH4XcdcRxPBRzsBLizTTJ49MJjF+jgu3qnO9GLQcQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -917,20 +907,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@hono/node-server": {
-      "version": "1.19.9",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
-      "integrity": "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=18.14.1"
-      },
-      "peerDependencies": {
-        "hono": "^4"
-      }
-    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -970,41 +946,26 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@mongodb-js/saslprep": {
-      "version": "1.4.6",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.4.6.tgz",
-      "integrity": "sha512-y+x3H1xBZd38n10NZF/rEBlvDOOMQ6LKUTHqr8R9VkJ+mmQOYtJFxIlkkK8fZrtOiL6VixbOBWMbZGBdal3Z1g==",
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.0.tgz",
+      "integrity": "sha512-kDoONqMa+VnZ4vvvu/ZUurpJ4gkZU57e7g69qpNgWhYcZFPUHZM2CEMKm+cG6ufDVALbjMvfmMjFVqaK7uEMnA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
+      "optional": true,
       "dependencies": {
-        "sparse-bitfield": "^3.0.3"
-      }
-    },
-    "node_modules/@mrleebo/prisma-ast": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/@mrleebo/prisma-ast/-/prisma-ast-0.13.1.tgz",
-      "integrity": "sha512-XyroGQXcHrZdvmrGJvsA9KNeOOgGMg1Vg9OlheUsBOSKznLMDl+YChxbkboRHvtFYJEMRYmlV3uoo/njCw05iw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "chevrotain": "^10.5.0",
-        "lilconfig": "^2.1.0"
+        "@tybys/wasm-util": "^0.10.3"
       },
       "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@mrleebo/prisma-ast/node_modules/lilconfig": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
-      "integrity": "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=10"
+        "node": "^20.19.0 || ^22.13.0 || >=23.5.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^2.0.0-alpha.3",
+        "@emnapi/runtime": "^2.0.0-alpha.3"
       }
     },
     "node_modules/@noble/ciphers": {
@@ -1033,6 +994,26 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz",
+      "integrity": "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
     "node_modules/@polka/url": {
       "version": "1.0.0-next.29",
       "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
@@ -1040,235 +1021,321 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@prisma/client": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-7.4.2.tgz",
-      "integrity": "sha512-ts2mu+cQHriAhSxngO3StcYubBGTWDtu/4juZhXCUKOwgh26l+s4KD3vT2kMUzFyrYnll9u/3qWrtzRv9CGWzA==",
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+      "cpu": [
+        "arm64"
+      ],
       "dev": true,
-      "license": "Apache-2.0",
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
       "dependencies": {
-        "@prisma/client-runtime-utils": "7.4.2"
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
       },
       "engines": {
-        "node": "^20.19 || ^22.12 || >=24.0"
-      },
-      "peerDependencies": {
-        "prisma": "*",
-        "typescript": ">=5.4.0"
-      },
-      "peerDependenciesMeta": {
-        "prisma": {
-          "optional": true
-        },
-        "typescript": {
-          "optional": true
-        }
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@prisma/client-runtime-utils": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@prisma/client-runtime-utils/-/client-runtime-utils-7.4.2.tgz",
-      "integrity": "sha512-cID+rzOEb38VyMsx5LwJMEY4NGIrWCNpKu/0ImbeooQ2Px7TI+kOt7cm0NelxUzF2V41UVVXAmYjANZQtCu1/Q==",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
-    "node_modules/@prisma/config": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-7.4.2.tgz",
-      "integrity": "sha512-CftBjWxav99lzY1Z4oDgomdb1gh9BJFAOmWF6P2v1xRfXqQb56DfBub+QKcERRdNoAzCb3HXy3Zii8Vb4AsXhg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "c12": "3.1.0",
-        "deepmerge-ts": "7.1.5",
-        "effect": "3.18.4",
-        "empathic": "2.0.0"
-      }
-    },
-    "node_modules/@prisma/config/node_modules/c12": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/c12/-/c12-3.1.0.tgz",
-      "integrity": "sha512-uWoS8OU1MEIsOv8p/5a82c3H31LsWVR5qiyXVfBNOzfffjUWtPnhAb4BYI2uG2HfGmZmFjCtui5XNWaps+iFuw==",
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
+      "optional": true,
       "dependencies": {
-        "chokidar": "^4.0.3",
-        "confbox": "^0.2.2",
-        "defu": "^6.1.4",
-        "dotenv": "^16.6.1",
-        "exsolve": "^1.0.7",
-        "giget": "^2.0.0",
-        "jiti": "^2.4.2",
-        "ohash": "^2.0.11",
-        "pathe": "^2.0.3",
-        "perfect-debounce": "^1.0.0",
-        "pkg-types": "^2.2.0",
-        "rc9": "^2.1.2"
-      },
-      "peerDependencies": {
-        "magicast": "^0.3.5"
-      },
-      "peerDependenciesMeta": {
-        "magicast": {
-          "optional": true
-        }
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
       }
     },
-    "node_modules/@prisma/config/node_modules/confbox": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.4.tgz",
-      "integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
       "dev": true,
       "license": "MIT",
-      "peer": true
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
     },
-    "node_modules/@prisma/config/node_modules/pkg-types": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.0.tgz",
-      "integrity": "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==",
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
+      "optional": true,
       "dependencies": {
-        "confbox": "^0.2.2",
-        "exsolve": "^1.0.7",
-        "pathe": "^2.0.3"
+        "tslib": "^2.4.0"
       }
     },
-    "node_modules/@prisma/debug": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-7.4.2.tgz",
-      "integrity": "sha512-aP7qzu+g/JnbF6U69LMwHoUkELiserKmWsE2shYuEpNUJ4GrtxBCvZwCyCBHFSH2kLTF2l1goBlBh4wuvRq62w==",
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+      "cpu": [
+        "arm64"
+      ],
       "dev": true,
-      "license": "Apache-2.0",
-      "peer": true
-    },
-    "node_modules/@prisma/dev": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@prisma/dev/-/dev-0.20.0.tgz",
-      "integrity": "sha512-ovlBYwWor0OzG+yH4J3Ot+AneD818BttLA+Ii7wjbcLHUrnC4tbUPVGyNd3c/+71KETPKZfjhkTSpdS15dmXNQ==",
-      "dev": true,
-      "license": "ISC",
-      "peer": true,
-      "dependencies": {
-        "@electric-sql/pglite": "0.3.15",
-        "@electric-sql/pglite-socket": "0.0.20",
-        "@electric-sql/pglite-tools": "0.2.20",
-        "@hono/node-server": "1.19.9",
-        "@mrleebo/prisma-ast": "0.13.1",
-        "@prisma/get-platform": "7.2.0",
-        "@prisma/query-plan-executor": "7.2.0",
-        "foreground-child": "3.3.1",
-        "get-port-please": "3.2.0",
-        "hono": "4.11.4",
-        "http-status-codes": "2.3.0",
-        "pathe": "2.0.3",
-        "proper-lockfile": "4.1.2",
-        "remeda": "2.33.4",
-        "std-env": "3.10.0",
-        "valibot": "1.2.0",
-        "zeptomatch": "2.1.0"
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@prisma/engines": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-7.4.2.tgz",
-      "integrity": "sha512-B+ZZhI4rXlzjVqRw/93AothEKOU5/x4oVyJFGo9RpHPnBwaPwk4Pi0Q4iGXipKxeXPs/dqljgNBjK0m8nocOJA==",
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+      "cpu": [
+        "x64"
+      ],
       "dev": true,
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@prisma/debug": "7.4.2",
-        "@prisma/engines-version": "7.5.0-10.94a226be1cf2967af2541cca5529f0f7ba866919",
-        "@prisma/fetch-engine": "7.4.2",
-        "@prisma/get-platform": "7.4.2"
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@prisma/engines-version": {
-      "version": "7.5.0-10.94a226be1cf2967af2541cca5529f0f7ba866919",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-7.5.0-10.94a226be1cf2967af2541cca5529f0f7ba866919.tgz",
-      "integrity": "sha512-5FIKY3KoYQlBuZC2yc16EXfVRQ8HY+fLqgxkYfWCtKhRb3ajCRzP/rPeoSx11+NueJDANdh4hjY36mdmrTcGSg==",
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
-      "license": "Apache-2.0",
-      "peer": true
-    },
-    "node_modules/@prisma/engines/node_modules/@prisma/get-platform": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.4.2.tgz",
-      "integrity": "sha512-UTnChXRwiauzl/8wT4hhe7Xmixja9WE28oCnGpBtRejaHhvekx5kudr3R4Y9mLSA0kqGnAMeyTiKwDVMjaEVsw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@prisma/debug": "7.4.2"
-      }
-    },
-    "node_modules/@prisma/fetch-engine": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-7.4.2.tgz",
-      "integrity": "sha512-f/c/MwYpdJO7taLETU8rahEstLeXfYgQGlz5fycG7Fbmva3iPdzGmjiSWHeSWIgNnlXnelUdCJqyZnFocurZuA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@prisma/debug": "7.4.2",
-        "@prisma/engines-version": "7.5.0-10.94a226be1cf2967af2541cca5529f0f7ba866919",
-        "@prisma/get-platform": "7.4.2"
-      }
-    },
-    "node_modules/@prisma/fetch-engine/node_modules/@prisma/get-platform": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.4.2.tgz",
-      "integrity": "sha512-UTnChXRwiauzl/8wT4hhe7Xmixja9WE28oCnGpBtRejaHhvekx5kudr3R4Y9mLSA0kqGnAMeyTiKwDVMjaEVsw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@prisma/debug": "7.4.2"
-      }
-    },
-    "node_modules/@prisma/get-platform": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.2.0.tgz",
-      "integrity": "sha512-k1V0l0Td1732EHpAfi2eySTezyllok9dXb6UQanajkJQzPUGi3vO2z7jdkz67SypFTdmbnyGYxvEvYZdZsMAVA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@prisma/debug": "7.2.0"
-      }
-    },
-    "node_modules/@prisma/get-platform/node_modules/@prisma/debug": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-7.2.0.tgz",
-      "integrity": "sha512-YSGTiSlBAVJPzX4ONZmMotL+ozJwQjRmZweQNIq/ER0tQJKJynNkRB3kyvt37eOfsbMCXk3gnLF6J9OJ4QWftw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true
-    },
-    "node_modules/@prisma/query-plan-executor": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@prisma/query-plan-executor/-/query-plan-executor-7.2.0.tgz",
-      "integrity": "sha512-EOZmNzcV8uJ0mae3DhTsiHgoNCuu1J9mULQpGCh62zN3PxPTd+qI9tJvk5jOst8WHKQNwJWR3b39t0XvfBB0WQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true
-    },
-    "node_modules/@prisma/studio-core": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/@prisma/studio-core/-/studio-core-0.13.1.tgz",
-      "integrity": "sha512-agdqaPEePRHcQ7CexEfkX1RvSH9uWDb6pXrZnhCRykhDFAV0/0P3d07WtfiY8hZWb7oRU4v+NkT4cGFHkQJIPg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "peerDependencies": {
-        "@types/react": "^18.0.0 || ^19.0.0",
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
+      "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.59.0",
@@ -1666,6 +1733,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -1692,33 +1770,14 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.3.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.0.tgz",
-      "integrity": "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A==",
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.18.0"
       }
-    },
-    "node_modules/@types/react": {
-      "version": "19.2.14",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
-      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "csstype": "^3.2.2"
-      }
-    },
-    "node_modules/@types/webidl-conversions": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
-      "integrity": "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/@types/whatwg-mimetype": {
       "version": "3.0.2",
@@ -1726,17 +1785,6 @@
       "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/whatwg-url": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-13.0.0.tgz",
-      "integrity": "sha512-N8WXpbE6Wgri7KUSvrmQcqrMllKZ9uxkYWMt+mCSGwNc0Hsw9VQTW7ApqI4XNrx6/SaM2QQJCzMPDEXE058s+Q==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/webidl-conversions": "*"
-      }
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",
@@ -1749,29 +1797,29 @@
       }
     },
     "node_modules/@vitest/coverage-v8": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.0.18.tgz",
-      "integrity": "sha512-7i+N2i0+ME+2JFZhfuz7Tg/FqKtilHjGyGvoHYQ6iLV0zahbsJ9sljC9OcFcPDbhYKCet+sG8SsVqlyGvPflZg==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.10.tgz",
+      "integrity": "sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
-        "@vitest/utils": "4.0.18",
-        "ast-v8-to-istanbul": "^0.3.10",
+        "@vitest/utils": "4.1.10",
+        "ast-v8-to-istanbul": "^1.0.0",
         "istanbul-lib-coverage": "^3.2.2",
         "istanbul-lib-report": "^3.0.1",
         "istanbul-reports": "^3.2.0",
-        "magicast": "^0.5.1",
+        "magicast": "^0.5.2",
         "obug": "^2.1.1",
-        "std-env": "^3.10.0",
-        "tinyrainbow": "^3.0.3"
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/browser": "4.0.18",
-        "vitest": "4.0.18"
+        "@vitest/browser": "4.1.10",
+        "vitest": "4.1.10"
       },
       "peerDependenciesMeta": {
         "@vitest/browser": {
@@ -1780,31 +1828,31 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
-      "integrity": "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.0.18",
-        "@vitest/utils": "4.0.18",
-        "chai": "^6.2.1",
-        "tinyrainbow": "^3.0.3"
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.18.tgz",
-      "integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.0.18",
+        "@vitest/spy": "4.1.10",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -1813,7 +1861,7 @@
       },
       "peerDependencies": {
         "msw": "^2.4.9",
-        "vite": "^6.0.0 || ^7.0.0-0"
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "msw": {
@@ -1825,26 +1873,26 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
-      "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tinyrainbow": "^3.0.3"
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.18.tgz",
-      "integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.0.18",
+        "@vitest/utils": "4.1.10",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -1852,13 +1900,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.18.tgz",
-      "integrity": "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.0.18",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -1867,9 +1916,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
-      "integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1877,36 +1926,37 @@
       }
     },
     "node_modules/@vitest/ui": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-4.0.18.tgz",
-      "integrity": "sha512-CGJ25bc8fRi8Lod/3GHSvXRKi7nBo3kxh0ApW4yCjmrWmRmlT53B5E08XRSZRliygG0aVNxLrBEqPYdz/KcCtQ==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-4.1.10.tgz",
+      "integrity": "sha512-EOUqfXHTXtpSHsyLHH40ts3Ue+hRhSGwzwzMlK0dTEOLSDYyOXLyr5JDGmHQWhN2DYI30gw6dVx3cdgM9FZl+Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.0.18",
+        "@vitest/utils": "4.1.10",
         "fflate": "^0.8.2",
-        "flatted": "^3.3.3",
+        "flatted": "^3.4.2",
         "pathe": "^2.0.3",
         "sirv": "^3.0.2",
         "tinyglobby": "^0.2.15",
-        "tinyrainbow": "^3.0.3"
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "vitest": "4.0.18"
+        "vitest": "4.1.10"
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
-      "integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.0.18",
-        "tinyrainbow": "^3.0.3"
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
@@ -1985,26 +2035,15 @@
       }
     },
     "node_modules/ast-v8-to-istanbul": {
-      "version": "0.3.11",
-      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.11.tgz",
-      "integrity": "sha512-Qya9fkoofMjCBNVdWINMjB5KZvkYfaO9/anwkWnjxibpWUxo5iHl2sOdP7/uAqaRuUYuoo8rDwnbaaKVFxoUvw==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.5.tgz",
+      "integrity": "sha512-UPAgKJFSEGMWSDr3LX4tqnAb4f7KGT8O40Tyx8wbYmmZ/yn58lNCm8h3svs3eXgiGd5AXxz8NDOvXWvicq+rJA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.31",
         "estree-walker": "^3.0.3",
         "js-tokens": "^10.0.0"
-      }
-    },
-    "node_modules/aws-ssl-profiles": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/aws-ssl-profiles/-/aws-ssl-profiles-1.1.2.tgz",
-      "integrity": "sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">= 6.0.0"
       }
     },
     "node_modules/balanced-match": {
@@ -2018,27 +2057,27 @@
       }
     },
     "node_modules/better-auth": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/better-auth/-/better-auth-1.5.0.tgz",
-      "integrity": "sha512-vbRKSxDa1vwXzEmR7+kXJMDs2pRXLOvD4MiqQwL4r6kkjzok5kOyLD200ZUg24Jtx2Xho1oA2drlxT6GqknH1A==",
+      "version": "1.6.25",
+      "resolved": "https://registry.npmjs.org/better-auth/-/better-auth-1.6.25.tgz",
+      "integrity": "sha512-fvoq+oCO+FF5fpP3XfU7znRyGFpHB77UG2EyxsKNy+Cak7Q5pELu+auvvDveQbWQxcoKugZ7jYQQPFQLpUTGOw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@better-auth/core": "1.5.0",
-        "@better-auth/drizzle-adapter": "1.5.0",
-        "@better-auth/kysely-adapter": "1.5.0",
-        "@better-auth/memory-adapter": "1.5.0",
-        "@better-auth/mongo-adapter": "1.5.0",
-        "@better-auth/prisma-adapter": "1.5.0",
-        "@better-auth/telemetry": "1.5.0",
-        "@better-auth/utils": "0.3.1",
-        "@better-fetch/fetch": "1.1.21",
+        "@better-auth/core": "1.6.25",
+        "@better-auth/drizzle-adapter": "1.6.25",
+        "@better-auth/kysely-adapter": "1.6.25",
+        "@better-auth/memory-adapter": "1.6.25",
+        "@better-auth/mongo-adapter": "1.6.25",
+        "@better-auth/prisma-adapter": "1.6.25",
+        "@better-auth/telemetry": "1.6.25",
+        "@better-auth/utils": "0.4.2",
+        "@better-fetch/fetch": "1.3.1",
         "@noble/ciphers": "^2.1.1",
         "@noble/hashes": "^2.0.1",
-        "better-call": "1.3.2",
+        "better-call": "1.3.7",
         "defu": "^6.1.4",
         "jose": "^6.1.3",
-        "kysely": "^0.28.11",
+        "kysely": "^0.28.17 || ^0.29.0",
         "nanostores": "^1.1.1",
         "zod": "^4.3.6"
       },
@@ -2050,7 +2089,7 @@
         "@tanstack/solid-start": "^1.0.0",
         "better-sqlite3": "^12.0.0",
         "drizzle-kit": ">=0.31.4",
-        "drizzle-orm": ">=0.41.0",
+        "drizzle-orm": "^0.45.2",
         "mongodb": "^6.0.0 || ^7.0.0",
         "mysql2": "^3.0.0",
         "next": "^14.0.0 || ^15.0.0 || ^16.0.0",
@@ -2124,13 +2163,13 @@
       }
     },
     "node_modules/better-call": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/better-call/-/better-call-1.3.2.tgz",
-      "integrity": "sha512-4cZIfrerDsNTn3cm+MhLbUePN0gdwkhSXEuG7r/zuQ8c/H7iU0/jSK5TD3FW7U0MgKHce/8jGpPYNO4Ve+4NBw==",
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/better-call/-/better-call-1.3.7.tgz",
+      "integrity": "sha512-Al51/hjp2SSp6CRTa3F2ptcx4yQVS1xWKoY6jcVXqNYOap6mHFP2jUBn5EwIL4iIed1/Sq4hlQ+Umm6EflZG+w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@better-auth/utils": "^0.3.1",
+        "@better-auth/utils": "^0.4.0",
         "@better-fetch/fetch": "^1.1.21",
         "rou3": "^0.7.12",
         "set-cookie-parser": "^3.0.1"
@@ -2145,9 +2184,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.2.tgz",
-      "integrity": "sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2170,15 +2209,17 @@
         "node": ">=8"
       }
     },
-    "node_modules/bson": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-7.2.0.tgz",
-      "integrity": "sha512-YCEo7KjMlbNlyHhz7zAZNDpIpQbd+wOEHJYezv0nMYTn4x31eIUM2yomNNubclAt63dObUzKHWsBLJ9QcZNSnQ==",
+    "node_modules/buffer-image-size": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/buffer-image-size/-/buffer-image-size-0.6.4.tgz",
+      "integrity": "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==",
       "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=4.0"
       }
     },
     "node_modules/bundle-require": {
@@ -2215,22 +2256,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/chevrotain": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-10.5.0.tgz",
-      "integrity": "sha512-Pkv5rBY3+CsHOYfV5g/Vs5JY9WTHHDEKOlohI2XeygaZhUeqhAlldZ8Hz9cRmxu709bvS08YzxHdTPHhffc13A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@chevrotain/cst-dts-gen": "10.5.0",
-        "@chevrotain/gast": "10.5.0",
-        "@chevrotain/types": "10.5.0",
-        "@chevrotain/utils": "10.5.0",
-        "lodash": "4.17.21",
-        "regexp-to-ast": "0.5.0"
       }
     },
     "node_modules/chokidar": {
@@ -2323,29 +2348,12 @@
         "node": "^14.18.0 || >=16.10.0"
       }
     },
-    "node_modules/cross-spawn": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
-      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "path-key": "^3.1.0",
-        "shebang-command": "^2.0.0",
-        "which": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/csstype": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
-      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -2375,194 +2383,21 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/deepmerge-ts": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.5.tgz",
-      "integrity": "sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "node_modules/defu": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
-      "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/denque": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
-      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
-        "node": ">=0.10"
-      }
-    },
-    "node_modules/destr": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
-      "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/dotenv": {
-      "version": "16.6.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
-      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
-      }
-    },
-    "node_modules/drizzle-orm": {
-      "version": "0.45.1",
-      "resolved": "https://registry.npmjs.org/drizzle-orm/-/drizzle-orm-0.45.1.tgz",
-      "integrity": "sha512-Te0FOdKIistGNPMq2jscdqngBRfBpC8uMFVwqjf6gtTVJHIQ/dosgV/CLBU2N4ZJBsXL5savCba9b0YJskKdcA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "peerDependencies": {
-        "@aws-sdk/client-rds-data": ">=3",
-        "@cloudflare/workers-types": ">=4",
-        "@electric-sql/pglite": ">=0.2.0",
-        "@libsql/client": ">=0.10.0",
-        "@libsql/client-wasm": ">=0.10.0",
-        "@neondatabase/serverless": ">=0.10.0",
-        "@op-engineering/op-sqlite": ">=2",
-        "@opentelemetry/api": "^1.4.1",
-        "@planetscale/database": ">=1.13",
-        "@prisma/client": "*",
-        "@tidbcloud/serverless": "*",
-        "@types/better-sqlite3": "*",
-        "@types/pg": "*",
-        "@types/sql.js": "*",
-        "@upstash/redis": ">=1.34.7",
-        "@vercel/postgres": ">=0.8.0",
-        "@xata.io/client": "*",
-        "better-sqlite3": ">=7",
-        "bun-types": "*",
-        "expo-sqlite": ">=14.0.0",
-        "gel": ">=2",
-        "knex": "*",
-        "kysely": "*",
-        "mysql2": ">=2",
-        "pg": ">=8",
-        "postgres": ">=3",
-        "sql.js": ">=1",
-        "sqlite3": ">=5"
-      },
-      "peerDependenciesMeta": {
-        "@aws-sdk/client-rds-data": {
-          "optional": true
-        },
-        "@cloudflare/workers-types": {
-          "optional": true
-        },
-        "@electric-sql/pglite": {
-          "optional": true
-        },
-        "@libsql/client": {
-          "optional": true
-        },
-        "@libsql/client-wasm": {
-          "optional": true
-        },
-        "@neondatabase/serverless": {
-          "optional": true
-        },
-        "@op-engineering/op-sqlite": {
-          "optional": true
-        },
-        "@opentelemetry/api": {
-          "optional": true
-        },
-        "@planetscale/database": {
-          "optional": true
-        },
-        "@prisma/client": {
-          "optional": true
-        },
-        "@tidbcloud/serverless": {
-          "optional": true
-        },
-        "@types/better-sqlite3": {
-          "optional": true
-        },
-        "@types/pg": {
-          "optional": true
-        },
-        "@types/sql.js": {
-          "optional": true
-        },
-        "@upstash/redis": {
-          "optional": true
-        },
-        "@vercel/postgres": {
-          "optional": true
-        },
-        "@xata.io/client": {
-          "optional": true
-        },
-        "better-sqlite3": {
-          "optional": true
-        },
-        "bun-types": {
-          "optional": true
-        },
-        "expo-sqlite": {
-          "optional": true
-        },
-        "gel": {
-          "optional": true
-        },
-        "knex": {
-          "optional": true
-        },
-        "kysely": {
-          "optional": true
-        },
-        "mysql2": {
-          "optional": true
-        },
-        "pg": {
-          "optional": true
-        },
-        "postgres": {
-          "optional": true
-        },
-        "prisma": {
-          "optional": true
-        },
-        "sql.js": {
-          "optional": true
-        },
-        "sqlite3": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/effect": {
-      "version": "3.18.4",
-      "resolved": "https://registry.npmjs.org/effect/-/effect-3.18.4.tgz",
-      "integrity": "sha512-b1LXQJLe9D11wfnOKAk3PKxuqYshQ0Heez+y5pnkd3jLj1yx9QhM72zZ9uUrOQyNvrs2GZZd/3maL0ZV18YuDA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@standard-schema/spec": "^1.0.0",
-        "fast-check": "^3.23.1"
+        "node": ">=8"
       }
     },
     "node_modules/emoji-regex": {
@@ -2571,17 +2406,6 @@
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/empathic": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.0.tgz",
-      "integrity": "sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=14"
-      }
     },
     "node_modules/entities": {
       "version": "7.0.1",
@@ -2610,9 +2434,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
-      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
       "dev": true,
       "license": "MIT"
     },
@@ -2685,42 +2509,10 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/exsolve": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
-      "integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/fast-check": {
-      "version": "3.23.2",
-      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.23.2.tgz",
-      "integrity": "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/dubzzz"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fast-check"
-        }
-      ],
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "pure-rand": "^6.1.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
     "node_modules/fflate": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
-      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
       "dev": true,
       "license": "MIT"
     },
@@ -2750,29 +2542,11 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.3.tgz",
+      "integrity": "sha512-/zipXxyO6rGvuNGDiULY9MvEGSkb2gaG4GGH4ygMi0ZZzyMHdUZBmntJmx5x1G2VuPytCwGN4xsJP6cw+sK+vQ==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/foreground-child": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
-      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
-      "dev": true,
-      "license": "ISC",
-      "peer": true,
-      "dependencies": {
-        "cross-spawn": "^7.0.6",
-        "signal-exit": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -2789,17 +2563,6 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
-    "node_modules/generate-function": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
-      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "is-property": "^1.0.2"
-      }
-    },
     "node_modules/get-east-asian-width": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
@@ -2811,44 +2574,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/get-port-please": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/get-port-please/-/get-port-please-3.2.0.tgz",
-      "integrity": "sha512-I9QVvBw5U/hw3RmWpYKRumUeaDgxTPd401x364rLmWBJcOQ753eov1eTgzDqRG9bqFIfDc7gfzcQEWrUri3o1A==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/giget": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/giget/-/giget-2.0.0.tgz",
-      "integrity": "sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "citty": "^0.1.6",
-        "consola": "^3.4.0",
-        "defu": "^6.1.4",
-        "node-fetch-native": "^1.6.6",
-        "nypm": "^0.6.0",
-        "pathe": "^2.0.3"
-      },
-      "bin": {
-        "giget": "dist/cli.mjs"
-      }
-    },
-    "node_modules/giget/node_modules/citty": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/citty/-/citty-0.1.6.tgz",
-      "integrity": "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "consola": "^3.2.3"
       }
     },
     "node_modules/glob": {
@@ -2869,43 +2594,20 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/graceful-fs": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
-      "license": "ISC",
-      "peer": true
-    },
-    "node_modules/grammex": {
-      "version": "3.1.12",
-      "resolved": "https://registry.npmjs.org/grammex/-/grammex-3.1.12.tgz",
-      "integrity": "sha512-6ufJOsSA7LcQehIJNCO7HIBykfM7DXQual0Ny780/DEcJIpBlHRvcqEBWGPYd7hrXL2GJ3oJI1MIhaXjWmLQOQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/graphmatch": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/graphmatch/-/graphmatch-1.1.1.tgz",
-      "integrity": "sha512-5ykVn/EXM1hF0XCaWh05VbYvEiOL2lY1kBxZtaYsyvjp7cmWOU1XsAdfQBwClraEofXDT197lFbXOEVMHpvQOg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/happy-dom": {
-      "version": "20.7.0",
-      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.7.0.tgz",
-      "integrity": "sha512-hR/uLYQdngTyEfxnOoa+e6KTcfBFyc1hgFj/Cc144A5JJUuHFYqIEBDcD4FeGqUeKLRZqJ9eN9u7/GDjYEgS1g==",
+      "version": "20.11.1",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.11.1.tgz",
+      "integrity": "sha512-XSt8tMzbW9ymE7687xztkO1ckR7qJNQ3LywY9vlYGhGi3zXrGBHuUo2Cl1ztZaICW+1eAGdkLbj6iwVqDT33kg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": ">=20.0.0",
         "@types/whatwg-mimetype": "^3.0.2",
         "@types/ws": "^8.18.1",
+        "buffer-image-size": "^0.6.4",
         "entities": "^7.0.1",
         "whatwg-mimetype": "^3.0.0",
-        "ws": "^8.18.3"
+        "ws": "^8.21.0"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -2921,49 +2623,12 @@
         "node": ">=8"
       }
     },
-    "node_modules/hono": {
-      "version": "4.12.3",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.3.tgz",
-      "integrity": "sha512-SFsVSjp8sj5UumXOOFlkZOG6XS9SJDKw0TbwFeV+AJ8xlST8kxK5Z/5EYa111UY8732lK2S/xB653ceuaoGwpg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=16.9.0"
-      }
-    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/http-status-codes": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.3.0.tgz",
-      "integrity": "sha512-RJ8XvFvpPM/Dmc5SV+dC4y5PCeOhT3x1Hq0NU3rjGeg5a/CqlhZ7uudknPwZFz4aeAXDcbAyaeP7GAo9lvngtA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/iconv-lite": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
-      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "5.1.0",
@@ -2990,22 +2655,6 @@
       "engines": {
         "node": ">=0.12.0"
       }
-    },
-    "node_modules/is-property": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-      "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/isexe": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
-      "license": "ISC",
-      "peer": true
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -3046,21 +2695,10 @@
         "node": ">=8"
       }
     },
-    "node_modules/jiti": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
-      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "bin": {
-        "jiti": "lib/jiti-cli.mjs"
-      }
-    },
     "node_modules/jose": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
-      "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.4.tgz",
+      "integrity": "sha512-N8acGzVsQy6M/fjFcxtysNc4Q379TcM5dM/qKkNtsHFji88yANnXTr7BLeP75iPnFwBfQzM/jg2BZ9+HZrHCZA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -3092,13 +2730,286 @@
       "license": "MIT"
     },
     "node_modules/kysely": {
-      "version": "0.28.11",
-      "resolved": "https://registry.npmjs.org/kysely/-/kysely-0.28.11.tgz",
-      "integrity": "sha512-zpGIFg0HuoC893rIjYX1BETkVWdDnzTzF5e0kWXJFg5lE0k1/LfNWBejrcnOFu8Q2Rfq/hTDTU7XLUM8QOrpzg==",
+      "version": "0.29.4",
+      "resolved": "https://registry.npmjs.org/kysely/-/kysely-0.29.4.tgz",
+      "integrity": "sha512-y5mVgQNkMbs1eK9Xyc0pmNdabN2wHhRYY/5r4W5HrUT1rYCEPeVNSj1RUJeSDKT3U0p+mXCvLgkrFuIafYI6BA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
       }
     },
     "node_modules/lilconfig": {
@@ -3174,14 +3085,6 @@
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
-    "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/log-update": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
@@ -3202,14 +3105,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/long": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
-      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true
-    },
     "node_modules/lru-cache": {
       "version": "11.2.6",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
@@ -3218,23 +3113,6 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
-      }
-    },
-    "node_modules/lru.min": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/lru.min/-/lru.min-1.1.4.tgz",
-      "integrity": "sha512-DqC6n3QQ77zdFpCMASA1a3Jlb64Hv2N2DciFGkO/4L9+q/IpIAuRlKOvCXabtRW6cQf8usbmM6BE/TOPysCdIA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "bun": ">=1.0.0",
-        "deno": ">=1.30.0",
-        "node": ">=8.0.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wellwelwel"
       }
     },
     "node_modules/magic-string": {
@@ -3274,14 +3152,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/memory-pager": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
-      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -3349,69 +3219,6 @@
         "ufo": "^1.6.1"
       }
     },
-    "node_modules/mongodb": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-7.1.0.tgz",
-      "integrity": "sha512-kMfnKunbolQYwCIyrkxNJFB4Ypy91pYqua5NargS/f8ODNSJxT03ZU3n1JqL4mCzbSih8tvmMEMLpKTT7x5gCg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@mongodb-js/saslprep": "^1.3.0",
-        "bson": "^7.1.1",
-        "mongodb-connection-string-url": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=20.19.0"
-      },
-      "peerDependencies": {
-        "@aws-sdk/credential-providers": "^3.806.0",
-        "@mongodb-js/zstd": "^7.0.0",
-        "gcp-metadata": "^7.0.1",
-        "kerberos": "^7.0.0",
-        "mongodb-client-encryption": ">=7.0.0 <7.1.0",
-        "snappy": "^7.3.2",
-        "socks": "^2.8.6"
-      },
-      "peerDependenciesMeta": {
-        "@aws-sdk/credential-providers": {
-          "optional": true
-        },
-        "@mongodb-js/zstd": {
-          "optional": true
-        },
-        "gcp-metadata": {
-          "optional": true
-        },
-        "kerberos": {
-          "optional": true
-        },
-        "mongodb-client-encryption": {
-          "optional": true
-        },
-        "snappy": {
-          "optional": true
-        },
-        "socks": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/mongodb-connection-string-url": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-7.0.1.tgz",
-      "integrity": "sha512-h0AZ9A7IDVwwHyMxmdMXKy+9oNlF0zFoahHiX3vQ8e3KFcSP3VmsmfvtRSuLPxmyv2vjIDxqty8smTgie/SNRQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@types/whatwg-url": "^13.0.0",
-        "whatwg-url": "^14.1.0"
-      },
-      "engines": {
-        "node": ">=20.19.0"
-      }
-    },
     "node_modules/mrmime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
@@ -3429,28 +3236,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/mysql2": {
-      "version": "3.15.3",
-      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.15.3.tgz",
-      "integrity": "sha512-FBrGau0IXmuqg4haEZRBfHNWB5mUARw6hNwPDXXGg0XzVJ50mr/9hb267lvpVMnhZ1FON3qNd4Xfcez1rbFwSg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "aws-ssl-profiles": "^1.1.1",
-        "denque": "^2.1.0",
-        "generate-function": "^2.3.1",
-        "iconv-lite": "^0.7.0",
-        "long": "^5.2.1",
-        "lru.min": "^1.0.0",
-        "named-placeholders": "^1.1.3",
-        "seq-queue": "^0.0.5",
-        "sqlstring": "^2.3.2"
-      },
-      "engines": {
-        "node": ">= 8.0"
-      }
-    },
     "node_modules/mz": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
@@ -3461,20 +3246,6 @@
         "any-promise": "^1.0.0",
         "object-assign": "^4.0.1",
         "thenify-all": "^1.0.0"
-      }
-    },
-    "node_modules/named-placeholders": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/named-placeholders/-/named-placeholders-1.1.6.tgz",
-      "integrity": "sha512-Tz09sEL2EEuv5fFowm419c1+a/jSMiBjI9gHxVLrVdbUkkNUUfjsVYs9pVZu5oCon/kmRh9TfLEObFtkVxmY0w==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "lru.min": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
       }
     },
     "node_modules/nano-spawn": {
@@ -3491,9 +3262,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -3510,9 +3281,9 @@
       }
     },
     "node_modules/nanostores": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/nanostores/-/nanostores-1.1.1.tgz",
-      "integrity": "sha512-EYJqS25r2iBeTtGQCHidXl1VfZ1jXM7Q04zXJOrMlxVVmD0ptxJaNux92n1mJ7c5lN3zTq12MhH/8x59nP+qmg==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/nanostores/-/nanostores-1.4.2.tgz",
+      "integrity": "sha512-Wxv8Roefr2nqtiRG0bnaFlpYqpIVtOEeJZHaH+4nGgOK1/7n6OHOuHCb/bhqrNQgZM8fyd0s1PqhdrJc9Ib44g==",
       "dev": true,
       "funding": [
         {
@@ -3524,14 +3295,6 @@
       "engines": {
         "node": "^20.0.0 || >=22.0.0"
       }
-    },
-    "node_modules/node-fetch-native": {
-      "version": "1.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
-      "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/nypm": {
       "version": "0.6.5",
@@ -3582,14 +3345,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/ohash": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
-      "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/onetime": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
@@ -3604,17 +3359,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/path-key": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/path-scurry": {
@@ -3641,14 +3385,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/perfect-debounce": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
-      "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -3657,9 +3393,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3705,9 +3441,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "funding": [
         {
@@ -3725,7 +3461,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -3776,143 +3512,6 @@
         }
       }
     },
-    "node_modules/postgres": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/postgres/-/postgres-3.4.7.tgz",
-      "integrity": "sha512-Jtc2612XINuBjIl/QTWsV5UvE8UHuNblcO3vVADSrKsrc6RqGX6lOW1cEo3CM2v0XG4Nat8nI+YM7/f26VxXLw==",
-      "dev": true,
-      "license": "Unlicense",
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://github.com/sponsors/porsager"
-      }
-    },
-    "node_modules/prisma": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-7.4.2.tgz",
-      "integrity": "sha512-2bP8Ruww3Q95Z2eH4Yqh4KAENRsj/SxbdknIVBfd6DmjPwmpsC4OVFMLOeHt6tM3Amh8ebjvstrUz3V/hOe1dA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@prisma/config": "7.4.2",
-        "@prisma/dev": "0.20.0",
-        "@prisma/engines": "7.4.2",
-        "@prisma/studio-core": "0.13.1",
-        "mysql2": "3.15.3",
-        "postgres": "3.4.7"
-      },
-      "bin": {
-        "prisma": "build/index.js"
-      },
-      "engines": {
-        "node": "^20.19 || ^22.12 || >=24.0"
-      },
-      "peerDependencies": {
-        "better-sqlite3": ">=9.0.0",
-        "typescript": ">=5.4.0"
-      },
-      "peerDependenciesMeta": {
-        "better-sqlite3": {
-          "optional": true
-        },
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/proper-lockfile": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
-      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.4",
-        "retry": "^0.12.0",
-        "signal-exit": "^3.0.2"
-      }
-    },
-    "node_modules/proper-lockfile/node_modules/signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true,
-      "license": "ISC",
-      "peer": true
-    },
-    "node_modules/punycode": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
-      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/pure-rand": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
-      "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/dubzzz"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fast-check"
-        }
-      ],
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/rc9": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/rc9/-/rc9-2.1.2.tgz",
-      "integrity": "sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "defu": "^6.1.4",
-        "destr": "^2.0.3"
-      }
-    },
-    "node_modules/react": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
-      "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/react-dom": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
-      "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "scheduler": "^0.27.0"
-      },
-      "peerDependencies": {
-        "react": "^19.2.4"
-      }
-    },
     "node_modules/readdirp": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
@@ -3925,25 +3524,6 @@
       "funding": {
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/regexp-to-ast": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/regexp-to-ast/-/regexp-to-ast-0.5.0.tgz",
-      "integrity": "sha512-tlbJqcMHnPKI9zSrystikWKwHkBqu2a/Sgw01h3zFjvYrMxEDYHzzoMZnUrbIfpTFEsoRnnviOXNCzFiSc54Qw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/remeda": {
-      "version": "2.33.4",
-      "resolved": "https://registry.npmjs.org/remeda/-/remeda-2.33.4.tgz",
-      "integrity": "sha512-ygHswjlc/opg2VrtiYvUOPLjxjtdKvjGz1/plDhkG66hjNjFr1xmfrs2ClNFo/E6TyUFiwYNh53bKV26oBoMGQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "url": "https://github.com/sponsors/remeda"
       }
     },
     "node_modules/resolve-from": {
@@ -3973,23 +3553,46 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/retry": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">= 4"
-      }
-    },
     "node_modules/rfdc": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/rolldown": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.139.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
+      }
     },
     "node_modules/rollup": {
       "version": "4.59.0",
@@ -4043,22 +3646,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/scheduler": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
-      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/semver": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
@@ -4072,44 +3659,12 @@
         "node": ">=10"
       }
     },
-    "node_modules/seq-queue": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/seq-queue/-/seq-queue-0.0.5.tgz",
-      "integrity": "sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q==",
-      "dev": true,
-      "peer": true
-    },
     "node_modules/set-cookie-parser": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.0.1.tgz",
-      "integrity": "sha512-n7Z7dXZhJbwuAHhNzkTti6Aw9QDDjZtm3JTpTGATIdNzdQz5GuFs22w90BcvF4INfnrL5xrX3oGsuqO5Dx3A1Q==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.2.tgz",
+      "integrity": "sha512-5/r/lTwbJ3zQ+qwdUFZYeRNqda7P5HD8zQKqlSjdGt1/S0cjLAphHusj4Y58ahDtWn/g32xrIS58/ikOvwl0Lw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/shebang-command": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "shebang-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/shebang-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/siginfo": {
       "version": "2.0.0",
@@ -4190,28 +3745,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/sparse-bitfield": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
-      "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "memory-pager": "^1.0.2"
-      }
-    },
-    "node_modules/sqlstring": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.3.tgz",
-      "integrity": "sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -4220,9 +3753,9 @@
       "license": "MIT"
     },
     "node_modules/std-env": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
-      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
       "dev": true,
       "license": "MIT"
     },
@@ -4353,14 +3886,14 @@
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -4388,9 +3921,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4401,9 +3934,9 @@
       }
     },
     "node_modules/tinyrainbow": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
-      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4433,20 +3966,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/tr46": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
-      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "punycode": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/tree-kill": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
@@ -4463,6 +3982,14 @@
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/tsup": {
       "version": "8.5.1",
@@ -4571,35 +4098,18 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/valibot": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.2.0.tgz",
-      "integrity": "sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "typescript": ">=5"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.27.0",
-        "fdir": "^6.5.0",
-        "picomatch": "^4.0.3",
-        "postcss": "^8.5.6",
-        "rollup": "^4.43.0",
-        "tinyglobby": "^0.2.15"
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
+        "tinyglobby": "^0.2.17"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -4615,9 +4125,10 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
-        "lightningcss": "^1.21.0",
         "sass": "^1.70.0",
         "sass-embedded": "^1.70.0",
         "stylus": ">=0.54.8",
@@ -4630,13 +4141,16 @@
         "@types/node": {
           "optional": true
         },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
         "jiti": {
           "optional": true
         },
         "less": {
-          "optional": true
-        },
-        "lightningcss": {
           "optional": true
         },
         "sass": {
@@ -4662,28 +4176,10 @@
         }
       }
     },
-    "node_modules/vite/node_modules/fdir": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "picomatch": "^3 || ^4"
-      },
-      "peerDependenciesMeta": {
-        "picomatch": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/vite/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4694,31 +4190,31 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
-      "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.0.18",
-        "@vitest/mocker": "4.0.18",
-        "@vitest/pretty-format": "4.0.18",
-        "@vitest/runner": "4.0.18",
-        "@vitest/snapshot": "4.0.18",
-        "@vitest/spy": "4.0.18",
-        "@vitest/utils": "4.0.18",
-        "es-module-lexer": "^1.7.0",
-        "expect-type": "^1.2.2",
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
         "obug": "^2.1.1",
         "pathe": "^2.0.3",
         "picomatch": "^4.0.3",
-        "std-env": "^3.10.0",
+        "std-env": "^4.0.0-rc.1",
         "tinybench": "^2.9.0",
         "tinyexec": "^1.0.2",
         "tinyglobby": "^0.2.15",
-        "tinyrainbow": "^3.0.3",
-        "vite": "^6.0.0 || ^7.0.0",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
@@ -4734,12 +4230,15 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.0.18",
-        "@vitest/browser-preview": "4.0.18",
-        "@vitest/browser-webdriverio": "4.0.18",
-        "@vitest/ui": "4.0.18",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
         "happy-dom": "*",
-        "jsdom": "*"
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "@edge-runtime/vm": {
@@ -4760,6 +4259,12 @@
         "@vitest/browser-webdriverio": {
           "optional": true
         },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
         "@vitest/ui": {
           "optional": true
         },
@@ -4768,13 +4273,16 @@
         },
         "jsdom": {
           "optional": true
+        },
+        "vite": {
+          "optional": false
         }
       }
     },
     "node_modules/vitest/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4794,17 +4302,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/webidl-conversions": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/whatwg-mimetype": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
@@ -4813,38 +4310,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/whatwg-url": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
-      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "tr46": "^5.1.0",
-        "webidl-conversions": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/which": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
-      "license": "ISC",
-      "peer": true,
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/node-which"
-      },
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/why-is-node-running": {
@@ -4901,9 +4366,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4923,9 +4388,9 @@
       }
     },
     "node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -4938,22 +4403,10 @@
         "url": "https://github.com/sponsors/eemeli"
       }
     },
-    "node_modules/zeptomatch": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/zeptomatch/-/zeptomatch-2.1.0.tgz",
-      "integrity": "sha512-KiGErG2J0G82LSpniV0CtIzjlJ10E04j02VOudJsPyPwNZgGnRKQy7I1R7GMyg/QswnE4l7ohSGrQbQbjXPPDA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "grammex": "^3.1.11",
-        "graphmatch": "^1.1.0"
-      }
-    },
     "node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "dev": true,
       "license": "MIT",
       "funding": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "better-auth-telegram",
-  "version": "1.5.0",
+  "version": "2.0.0",
   "type": "module",
   "description": "Telegram authentication plugin for Better Auth",
   "main": "./dist/index.cjs",
@@ -66,27 +66,23 @@
   },
   "homepage": "https://github.com/vcode-sh/better-auth-telegram#readme",
   "peerDependencies": {
-    "better-auth": "^1.5.0"
+    "better-auth": ">=1.6.22 <1.7.0"
   },
   "engines": {
     "node": ">=22.0.0"
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.4",
-    "@types/node": "^25.3.0",
-    "@vitest/coverage-v8": "4.0.18",
-    "@vitest/ui": "^4.0.18",
-    "better-auth": "1.5.0",
-    "happy-dom": "20.7.0",
+    "@types/node": "^24.13.3",
+    "@vitest/coverage-v8": "4.1.10",
+    "@vitest/ui": "^4.1.10",
+    "better-auth": "1.6.25",
+    "happy-dom": "20.11.1",
     "lint-staged": "16.2.7",
     "tsup": "8.5.1",
     "typescript": "5.9.3",
     "ultracite": "7.2.3",
-    "vitest": "4.0.18"
-  },
-  "overrides": {
-    "hono": "4.12.3",
-    "lodash": "4.17.23"
+    "vitest": "4.1.10"
   },
   "lint-staged": {
     "*.{ts,tsx,js,jsx,json,css}": [

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -22,10 +22,12 @@ describe("telegramClient", () => {
 
     // Clear any global Telegram object
     (window as any).Telegram = undefined;
+    window.location.hash = "";
   });
 
   afterEach(() => {
     vi.clearAllMocks();
+    vi.unstubAllGlobals();
   });
 
   describe("Plugin structure", () => {
@@ -272,6 +274,16 @@ describe("telegramClient", () => {
       await expect(
         actions.initTelegramWidget("telegram-login", {}, async () => {})
       ).rejects.toThrow("Failed to get Telegram config");
+    });
+
+    it("should reject Widget initialization when botUsername is unavailable", async () => {
+      mockFetch.mockResolvedValueOnce({ data: { botUsername: "" } });
+
+      const actions = client.getActions(mockFetch);
+
+      await expect(
+        actions.initTelegramWidget("telegram-login", {}, async () => {})
+      ).rejects.toThrow("Telegram plugin: botUsername is required");
     });
 
     it("should clear container before adding widget", async () => {
@@ -690,6 +702,66 @@ describe("telegramClient", () => {
         await expect(actions.autoSignInFromMiniApp()).rejects.toThrow(
           "Not running in Telegram Mini App or initData not available"
         );
+      });
+
+      it("should use tgWebAppData from the URL fragment when the SDK is unavailable", async () => {
+        const mockInitData =
+          "user=%7B%22id%22%3A123%7D&auth_date=1234567890&hash=abc123";
+        (window as any).Telegram = undefined;
+        window.location.hash = `#tgWebAppVersion=9.0&tgWebAppData=${encodeURIComponent(
+          mockInitData
+        )}`;
+        mockFetch.mockResolvedValueOnce({ data: { user: { id: "123" } } });
+
+        const actions = client.getActions(mockFetch);
+        await actions.autoSignInFromMiniApp();
+
+        expect(mockFetch).toHaveBeenCalledWith("/telegram/miniapp/signin", {
+          method: "POST",
+          body: { initData: mockInitData },
+        });
+      });
+
+      it("should prefer SDK initData over tgWebAppData from the URL fragment", async () => {
+        const sdkInitData = "auth_date=1&hash=sdk";
+        const fragmentInitData = "auth_date=2&hash=fragment";
+        (window as any).Telegram = {
+          WebApp: {
+            initData: sdkInitData,
+          },
+        };
+        window.location.hash = `#tgWebAppData=${encodeURIComponent(
+          fragmentInitData
+        )}`;
+        mockFetch.mockResolvedValueOnce({ data: { user: { id: "123" } } });
+
+        const actions = client.getActions(mockFetch);
+        await actions.autoSignInFromMiniApp();
+
+        expect(mockFetch).toHaveBeenCalledWith("/telegram/miniapp/signin", {
+          method: "POST",
+          body: { initData: sdkInitData },
+        });
+      });
+
+      it("should reject safely when the URL fragment cannot be parsed", async () => {
+        (window as any).Telegram = undefined;
+        window.location.hash = "#tgWebAppData=broken";
+        vi.stubGlobal(
+          "URLSearchParams",
+          class {
+            constructor() {
+              throw new Error("invalid fragment");
+            }
+          }
+        );
+
+        const actions = client.getActions(mockFetch);
+
+        await expect(actions.autoSignInFromMiniApp()).rejects.toThrow(
+          "Not running in Telegram Mini App or initData not available"
+        );
+        expect(mockFetch).not.toHaveBeenCalled();
       });
 
       it("should throw if initData not available", async () => {

--- a/src/client.ts
+++ b/src/client.ts
@@ -69,6 +69,32 @@ function loadTelegramWidgetScript(): Promise<void> {
   });
 }
 
+function requireBotUsername(botUsername: string | undefined): string {
+  if (!botUsername) {
+    throw new Error("Telegram plugin: botUsername is required");
+  }
+
+  return botUsername;
+}
+
+function getMiniAppInitData(): string | undefined {
+  const sdkInitData = (window as any).Telegram?.WebApp?.initData;
+  if (sdkInitData) {
+    return sdkInitData;
+  }
+
+  try {
+    const hash = window.location.hash;
+    if (!hash) {
+      return undefined;
+    }
+
+    return new URLSearchParams(hash.slice(1)).get("tgWebAppData") || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 /**
  * Client plugin for Telegram authentication
  */
@@ -172,7 +198,7 @@ export const telegramClient = () => {
         await loadTelegramWidgetScript();
 
         // Get bot username from server
-        const configResponse = await $fetch<{ botUsername: string }>(
+        const configResponse = await $fetch<{ botUsername?: string }>(
           "/telegram/config",
           {
             method: "GET",
@@ -184,6 +210,7 @@ export const telegramClient = () => {
         }
 
         const config = configResponse.data;
+        const botUsername = requireBotUsername(config.botUsername);
         const {
           size = "large",
           showUserPhoto = true,
@@ -212,7 +239,7 @@ export const telegramClient = () => {
         const script = document.createElement("script");
         script.src = TELEGRAM_WIDGET_SCRIPT;
         script.async = true;
-        script.setAttribute("data-telegram-login", config.botUsername);
+        script.setAttribute("data-telegram-login", botUsername);
         script.setAttribute("data-size", size);
         script.setAttribute("data-userpic", showUserPhoto.toString());
         script.setAttribute("data-radius", cornerRadius.toString());
@@ -252,7 +279,7 @@ export const telegramClient = () => {
         await loadTelegramWidgetScript();
 
         // Get bot username from server
-        const configResponse = await $fetch<{ botUsername: string }>(
+        const configResponse = await $fetch<{ botUsername?: string }>(
           "/telegram/config",
           {
             method: "GET",
@@ -264,6 +291,7 @@ export const telegramClient = () => {
         }
 
         const config = configResponse.data;
+        const botUsername = requireBotUsername(config.botUsername);
         const {
           size = "large",
           showUserPhoto = true,
@@ -284,7 +312,7 @@ export const telegramClient = () => {
         const script = document.createElement("script");
         script.src = TELEGRAM_WIDGET_SCRIPT;
         script.async = true;
-        script.setAttribute("data-telegram-login", config.botUsername);
+        script.setAttribute("data-telegram-login", botUsername);
         script.setAttribute("data-size", size);
         script.setAttribute("data-userpic", showUserPhoto.toString());
         script.setAttribute("data-radius", cornerRadius.toString());
@@ -377,14 +405,13 @@ export const telegramClient = () => {
           throw new Error("This method can only be called in browser");
         }
 
-        const Telegram = (window as any).Telegram;
-        if (!Telegram?.WebApp?.initData) {
+        const initData = getMiniAppInitData();
+        if (!initData) {
           throw new Error(
             "Not running in Telegram Mini App or initData not available"
           );
         }
 
-        const initData = Telegram.WebApp.initData;
         return await $fetch("/telegram/miniapp/signin", {
           method: "POST",
           body: { initData },

--- a/src/client.ts
+++ b/src/client.ts
@@ -10,6 +10,14 @@ type TelegramPlugin = typeof telegram;
  */
 type FetchOptions = Record<string, any>;
 
+interface TelegramConfigResponse {
+  botUsername: string;
+  loginWidgetEnabled: boolean;
+  miniAppEnabled: boolean;
+  oidcEnabled: boolean;
+  testMode: boolean;
+}
+
 /**
  * Telegram Login Widget script URL
  */
@@ -158,14 +166,13 @@ export const telegramClient = () => {
        * @param fetchOptions - Optional fetch options (e.g., custom headers, cache control)
        */
       getTelegramConfig: async (fetchOptions?: FetchOptions) => {
-        const response = await $fetch<{
-          botUsername: string;
-          loginWidgetEnabled: boolean;
-          testMode: boolean;
-        }>("/telegram/config", {
-          method: "GET",
-          ...fetchOptions,
-        });
+        const response = await $fetch<TelegramConfigResponse>(
+          "/telegram/config",
+          {
+            method: "GET",
+            ...fetchOptions,
+          }
+        );
 
         return response;
       },
@@ -198,7 +205,7 @@ export const telegramClient = () => {
         await loadTelegramWidgetScript();
 
         // Get bot username from server
-        const configResponse = await $fetch<{ botUsername?: string }>(
+        const configResponse = await $fetch<TelegramConfigResponse>(
           "/telegram/config",
           {
             method: "GET",
@@ -279,7 +286,7 @@ export const telegramClient = () => {
         await loadTelegramWidgetScript();
 
         // Get bot username from server
-        const configResponse = await $fetch<{ botUsername?: string }>(
+        const configResponse = await $fetch<TelegramConfigResponse>(
           "/telegram/config",
           {
             method: "GET",

--- a/src/miniapp-endpoints.test.ts
+++ b/src/miniapp-endpoints.test.ts
@@ -132,6 +132,16 @@ describe("signInWithMiniApp", () => {
     );
   });
 
+  it("rejects use of Mini App sign-in when botToken is unavailable", async () => {
+    const endpoints = createMiniAppEndpoints(makeConfig({ botToken: "" }));
+    const ctx = mockCtx(mockAdapter(), { initData: INIT_DATA });
+
+    await expect((endpoints.signInWithMiniApp as any)(ctx)).rejects.toThrow(
+      ERROR_CODES.BOT_TOKEN_REQUIRED.message
+    );
+    expect(mockedVerify).not.toHaveBeenCalled();
+  });
+
   it("rejects when initData is not a string", async () => {
     const endpoints = createMiniAppEndpoints(makeConfig());
     const ctx = mockCtx(mockAdapter(), { initData: 12345 });
@@ -389,6 +399,16 @@ describe("validateMiniApp", () => {
     await expect((endpoints.validateMiniApp as any)(ctx)).rejects.toThrow(
       ERROR_CODES.INIT_DATA_REQUIRED.message
     );
+  });
+
+  it("rejects validation when botToken is unavailable", async () => {
+    const endpoints = createMiniAppEndpoints(makeConfig({ botToken: "" }));
+    const ctx = mockCtx(mockAdapter(), { initData: INIT_DATA });
+
+    await expect((endpoints.validateMiniApp as any)(ctx)).rejects.toThrow(
+      ERROR_CODES.BOT_TOKEN_REQUIRED.message
+    );
+    expect(mockedVerify).not.toHaveBeenCalled();
   });
 
   it("rejects when initData is not a string", async () => {

--- a/src/miniapp-endpoints.ts
+++ b/src/miniapp-endpoints.ts
@@ -28,6 +28,13 @@ export function createMiniAppEndpoints(config: TelegramPluginConfig) {
           throw APIError.from("BAD_REQUEST", ERROR_CODES.INIT_DATA_REQUIRED);
         }
 
+        if (!config.botToken) {
+          throw APIError.from(
+            "INTERNAL_SERVER_ERROR",
+            ERROR_CODES.BOT_TOKEN_REQUIRED
+          );
+        }
+
         // Verify initData
         if (
           config.miniAppValidateInitData &&
@@ -182,6 +189,13 @@ export function createMiniAppEndpoints(config: TelegramPluginConfig) {
 
         if (!initData || typeof initData !== "string") {
           throw APIError.from("BAD_REQUEST", ERROR_CODES.INIT_DATA_REQUIRED);
+        }
+
+        if (!config.botToken) {
+          throw APIError.from(
+            "INTERNAL_SERVER_ERROR",
+            ERROR_CODES.BOT_TOKEN_REQUIRED
+          );
         }
 
         const isValid = await verifyMiniAppInitData(

--- a/src/oidc.test.ts
+++ b/src/oidc.test.ts
@@ -2,7 +2,15 @@
  * @vitest-environment happy-dom
  */
 import { exportJWK, generateKeyPair, SignJWT } from "jose";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  expectTypeOf,
+  it,
+  vi,
+} from "vitest";
 import {
   TELEGRAM_OIDC_AUTH_ENDPOINT,
   TELEGRAM_OIDC_ISSUER,
@@ -36,6 +44,23 @@ const mockedValidateAuthorizationCode = vi.mocked(validateAuthorizationCode);
 
 const BOT_TOKEN = "123456789:ABCdefGHIjklMNOpqrsTUVwxyz";
 const BOT_ID = "123456789";
+
+describe("TelegramOIDCClaims", () => {
+  it("models Telegram profile and phone verification claims", () => {
+    expectTypeOf<TelegramOIDCClaims["id"]>().toEqualTypeOf<
+      number | undefined
+    >();
+    expectTypeOf<TelegramOIDCClaims["given_name"]>().toEqualTypeOf<
+      string | undefined
+    >();
+    expectTypeOf<TelegramOIDCClaims["family_name"]>().toEqualTypeOf<
+      string | undefined
+    >();
+    expectTypeOf<TelegramOIDCClaims["phone_number_verified"]>().toEqualTypeOf<
+      boolean | undefined
+    >();
+  });
+});
 
 describe("buildScopes", () => {
   it("should include openid by default", () => {
@@ -242,6 +267,36 @@ describe("createTelegramOIDCProvider", () => {
       });
 
       expect(result).toBe(mockUrl);
+    });
+
+    it("should reject authorization when neither botToken nor OIDC credentials are configured", () => {
+      const provider = createTelegramOIDCProvider("", {});
+
+      expect(() =>
+        provider.createAuthorizationURL({
+          state: "state",
+          codeVerifier: "verifier",
+          scopes: [],
+          redirectURI: "https://example.com/callback",
+        })
+      ).toThrow("clientId");
+      expect(mockedCreateAuthorizationURL).not.toHaveBeenCalled();
+    });
+
+    it("should reject authorization when clientSecret is missing", () => {
+      const provider = createTelegramOIDCProvider("", {
+        clientId: "123456789",
+      });
+
+      expect(() =>
+        provider.createAuthorizationURL({
+          state: "state",
+          codeVerifier: "verifier",
+          scopes: [],
+          redirectURI: "https://example.com/callback",
+        })
+      ).toThrow("clientSecret");
+      expect(mockedCreateAuthorizationURL).not.toHaveBeenCalled();
     });
 
     it("should include additional scopes passed directly", async () => {
@@ -595,6 +650,38 @@ describe("createTelegramOIDCProvider", () => {
       expect(mockedBetterFetch).toHaveBeenCalledWith(TELEGRAM_OIDC_JWKS_URI);
     });
 
+    it.each([
+      "ES256",
+      "EdDSA",
+    ] as const)("should verify a valid %s JWT token", async (algorithm) => {
+      const keyPair = await generateKeyPair(algorithm);
+      const exportedJwk = await exportJWK(keyPair.publicKey);
+      mockedBetterFetch.mockResolvedValueOnce({
+        data: {
+          keys: [
+            {
+              ...exportedJwk,
+              kid: "algorithm-test-kid",
+              alg: algorithm,
+              use: "sig",
+            },
+          ],
+        },
+      } as any);
+
+      const token = await new SignJWT({ sub: "12345" })
+        .setProtectedHeader({ alg: algorithm, kid: "algorithm-test-kid" })
+        .setIssuedAt()
+        .setExpirationTime("1h")
+        .setIssuer(TELEGRAM_OIDC_ISSUER)
+        .setAudience(BOT_ID)
+        .sign(keyPair.privateKey);
+
+      const provider = createTelegramOIDCProvider(BOT_TOKEN);
+
+      await expect(provider.verifyIdToken!(token)).resolves.toBe(true);
+    });
+
     it("should return false when JWT header has no kid", async () => {
       // Create a JWT without kid in header
       const token = new SignJWT({ sub: "12345" })
@@ -608,6 +695,49 @@ describe("createTelegramOIDCProvider", () => {
 
       const provider = createTelegramOIDCProvider(BOT_TOKEN);
       const result = await provider.verifyIdToken!(signedToken);
+
+      expect(result).toBe(false);
+    });
+
+    it("should reject unsupported signing algorithms before fetching JWKS", async () => {
+      const header = Buffer.from(
+        JSON.stringify({ alg: "HS256", kid: "test-kid-1" })
+      ).toString("base64url");
+      const payload = Buffer.from(
+        JSON.stringify({
+          sub: "12345",
+          iss: TELEGRAM_OIDC_ISSUER,
+          aud: BOT_ID,
+          exp: Math.floor(Date.now() / 1000) + 3600,
+        })
+      ).toString("base64url");
+      const token = `${header}.${payload}.invalid-signature`;
+
+      const provider = createTelegramOIDCProvider(BOT_TOKEN);
+      const result = await provider.verifyIdToken!(token);
+
+      expect(result).toBe(false);
+      expect(mockedBetterFetch).not.toHaveBeenCalled();
+    });
+
+    it("should reject token verification when clientId is missing", async () => {
+      const token = await createSignedJWT({ sub: "12345" });
+      const provider = createTelegramOIDCProvider("", {
+        clientSecret: "oidc-secret",
+      });
+
+      await expect(provider.verifyIdToken!(token)).resolves.toBe(false);
+      expect(mockedBetterFetch).not.toHaveBeenCalled();
+    });
+
+    it("should reject a JWK whose algorithm does not match the token header", async () => {
+      mockedBetterFetch.mockResolvedValueOnce({
+        data: { keys: [{ ...jwk, alg: undefined }] },
+      } as any);
+
+      const token = await createSignedJWT({ sub: "12345" });
+      const provider = createTelegramOIDCProvider(BOT_TOKEN);
+      const result = await provider.verifyIdToken!(token);
 
       expect(result).toBe(false);
     });
@@ -1375,32 +1505,6 @@ describe("Adversarial: config endpoint shape with testMode", () => {
     // Verify matchers don't match wrong paths
     expect(plugin.rateLimit[0]!.pathMatcher("/telegram/link")).toBe(false);
     expect(plugin.rateLimit[1]!.pathMatcher("/telegram/signin")).toBe(false);
-  });
-});
-
-describe("Adversarial: plugin constructor error cases", () => {
-  it("should throw when botToken is empty string", async () => {
-    const { telegram } = await import("./index");
-    expect(() => telegram({ botToken: "", botUsername: "test_bot" })).toThrow();
-  });
-
-  it("should throw when botUsername is empty string", async () => {
-    const { telegram } = await import("./index");
-    expect(() => telegram({ botToken: BOT_TOKEN, botUsername: "" })).toThrow();
-  });
-
-  it("should throw the specific BOT_TOKEN_REQUIRED message", async () => {
-    const { telegram } = await import("./index");
-    expect(() => telegram({ botToken: "", botUsername: "test_bot" })).toThrow(
-      "Telegram plugin: botToken is required"
-    );
-  });
-
-  it("should throw the specific BOT_USERNAME_REQUIRED message", async () => {
-    const { telegram } = await import("./index");
-    expect(() => telegram({ botToken: BOT_TOKEN, botUsername: "" })).toThrow(
-      "Telegram plugin: botUsername is required"
-    );
   });
 });
 

--- a/src/oidc.test.ts
+++ b/src/oidc.test.ts
@@ -742,6 +742,22 @@ describe("createTelegramOIDCProvider", () => {
       expect(result).toBe(false);
     });
 
+    it("should select the JWK matching both kid and algorithm", async () => {
+      mockedBetterFetch.mockResolvedValueOnce({
+        data: {
+          keys: [
+            { ...jwk, alg: "ES256" },
+            { ...jwk, alg: "RS256" },
+          ],
+        },
+      } as any);
+
+      const token = await createSignedJWT({ sub: "12345" });
+      const provider = createTelegramOIDCProvider(BOT_TOKEN);
+
+      await expect(provider.verifyIdToken!(token)).resolves.toBe(true);
+    });
+
     it("should return false when JWKS fetch fails", async () => {
       mockedBetterFetch.mockResolvedValueOnce({
         data: null,

--- a/src/oidc.ts
+++ b/src/oidc.ts
@@ -34,15 +34,9 @@ const getTelegramPublicKey = async (kid: string, algorithm: string) => {
     throw new Error("Failed to fetch Telegram JWKS");
   }
 
-  const jwk = data.keys.find((key) => key.kid === kid);
+  const jwk = data.keys.find((key) => key.kid === kid && key.alg === algorithm);
   if (!jwk) {
-    throw new Error(`JWK with kid ${kid} not found`);
-  }
-
-  if (jwk.alg !== algorithm) {
-    throw new Error(
-      `JWK algorithm does not match token algorithm ${algorithm}`
-    );
+    throw new Error(`JWK with kid ${kid} and algorithm ${algorithm} not found`);
   }
 
   return await importJWK(jwk, algorithm);

--- a/src/oidc.ts
+++ b/src/oidc.ts
@@ -4,7 +4,13 @@ import {
   validateAuthorizationCode,
 } from "@better-auth/core/oauth2";
 import { betterFetch } from "@better-fetch/fetch";
-import { decodeJwt, decodeProtectedHeader, importJWK, jwtVerify } from "jose";
+import {
+  decodeJwt,
+  decodeProtectedHeader,
+  importJWK,
+  type JWK,
+  jwtVerify,
+} from "jose";
 import {
   TELEGRAM_OIDC_AUTH_ENDPOINT,
   TELEGRAM_OIDC_ISSUER,
@@ -17,16 +23,11 @@ import type { TelegramOIDCClaims, TelegramOIDCOptions } from "./types";
 /**
  * Fetches a public key from Telegram's JWKS endpoint by key ID
  */
-const getTelegramPublicKey = async (kid: string) => {
+const SUPPORTED_SIGNING_ALGORITHMS = new Set(["RS256", "ES256", "EdDSA"]);
+
+const getTelegramPublicKey = async (kid: string, algorithm: string) => {
   const { data } = await betterFetch<{
-    keys: Array<{
-      kid: string;
-      kty: string;
-      use: string;
-      alg: string;
-      n: string;
-      e: string;
-    }>;
+    keys: JWK[];
   }>(TELEGRAM_OIDC_JWKS_URI);
 
   if (!data?.keys) {
@@ -38,7 +39,13 @@ const getTelegramPublicKey = async (kid: string) => {
     throw new Error(`JWK with kid ${kid} not found`);
   }
 
-  return await importJWK(jwk, jwk.alg);
+  if (jwk.alg !== algorithm) {
+    throw new Error(
+      `JWK algorithm does not match token algorithm ${algorithm}`
+    );
+  }
+
+  return await importJWK(jwk, algorithm);
 };
 
 /**
@@ -86,7 +93,11 @@ export function createTelegramOIDCProvider(
   // Falls back to bot token values for backward compatibility.
   const clientId = options.clientId || botId;
   const clientSecret = options.clientSecret || botToken;
-  if (!options.clientSecret) {
+  if (!(options.clientSecret || botToken)) {
+    console.warn(
+      "[better-auth-telegram] OIDC: clientSecret is required before starting an OIDC login."
+    );
+  } else if (!options.clientSecret) {
     console.warn(
       "[better-auth-telegram] OIDC: no clientSecret provided. Using bot token as fallback.",
       "For OIDC to work, configure Web Login in @BotFather (Bot Settings > Web Login)",
@@ -99,11 +110,26 @@ export function createTelegramOIDCProvider(
     clientSecret,
   };
 
+  const requireOIDCCredentials = () => {
+    if (!clientId) {
+      throw new Error(
+        "[better-auth-telegram] OIDC: clientId is required before starting an OIDC login."
+      );
+    }
+    if (!clientSecret) {
+      throw new Error(
+        "[better-auth-telegram] OIDC: clientSecret is required before starting an OIDC login."
+      );
+    }
+  };
+
   return {
     id: TELEGRAM_OIDC_PROVIDER_ID,
     name: "Telegram",
 
     createAuthorizationURL({ state, codeVerifier, scopes, redirectURI }) {
+      requireOIDCCredentials();
+
       const _scopes = buildScopes(options);
       if (scopes) {
         _scopes.push(...scopes);
@@ -121,6 +147,8 @@ export function createTelegramOIDCProvider(
     },
 
     validateAuthorizationCode({ code, codeVerifier, redirectURI }) {
+      requireOIDCCredentials();
+
       return validateAuthorizationCode({
         code,
         codeVerifier,
@@ -136,8 +164,14 @@ export function createTelegramOIDCProvider(
         if (!(kid && alg)) {
           return false;
         }
+        if (!clientId) {
+          return false;
+        }
+        if (!SUPPORTED_SIGNING_ALGORITHMS.has(alg)) {
+          return false;
+        }
 
-        const publicKey = await getTelegramPublicKey(kid);
+        const publicKey = await getTelegramPublicKey(kid, alg);
         const { payload } = await jwtVerify(token, publicKey, {
           algorithms: [alg],
           issuer: TELEGRAM_OIDC_ISSUER,

--- a/src/plugin-config.test.ts
+++ b/src/plugin-config.test.ts
@@ -10,16 +10,74 @@ const BASE = {
 describe("createPluginConfig", () => {
   // ── Validation ─────────────────────────────────────────────────────
 
-  it("throws when botToken is missing", () => {
-    expect(() =>
-      createPluginConfig({ botToken: "", botUsername: "bot" })
-    ).toThrow(ERROR_CODES.BOT_TOKEN_REQUIRED.message);
+  it("warns instead of throwing when the default Widget flow has no botToken", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    expect(() => createPluginConfig({ botUsername: "bot" })).not.toThrow();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining(ERROR_CODES.BOT_TOKEN_REQUIRED.message)
+    );
+
+    warnSpy.mockRestore();
   });
 
-  it("throws when botUsername is missing", () => {
-    expect(() =>
-      createPluginConfig({ botToken: "tok:en", botUsername: "" })
-    ).toThrow(ERROR_CODES.BOT_USERNAME_REQUIRED.message);
+  it("warns instead of throwing when the default Widget flow has no botUsername", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    expect(() => createPluginConfig({ botToken: "tok:en" })).not.toThrow();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining(ERROR_CODES.BOT_USERNAME_REQUIRED.message)
+    );
+
+    warnSpy.mockRestore();
+  });
+
+  it("allows OIDC-only configuration with explicit OIDC credentials", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const config = createPluginConfig({
+      loginWidget: false,
+      oidc: {
+        enabled: true,
+        clientId: "123456789",
+        clientSecret: "oidc-secret",
+      },
+    });
+
+    expect(config.botToken).toBe("");
+    expect(config.botUsername).toBe("");
+    expect(warnSpy).not.toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+  });
+
+  it("warns for each missing credential in an OIDC-only configuration", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    createPluginConfig({
+      loginWidget: false,
+      oidc: { enabled: true },
+    });
+
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+    expect(warnSpy.mock.calls[0]![0]).toContain("clientId is required");
+    expect(warnSpy.mock.calls[1]![0]).toContain("clientSecret is required");
+
+    warnSpy.mockRestore();
+  });
+
+  it("does not require botUsername for a Mini App-only configuration", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    createPluginConfig({
+      botToken: "tok:en",
+      loginWidget: false,
+      miniApp: { enabled: true },
+    });
+
+    expect(warnSpy).not.toHaveBeenCalled();
+
+    warnSpy.mockRestore();
   });
 
   // ── Defaults ───────────────────────────────────────────────────────

--- a/src/plugin-config.ts
+++ b/src/plugin-config.ts
@@ -38,8 +38,9 @@ export interface TelegramPluginConfig {
 }
 
 /**
- * Parses and validates `TelegramPluginOptions`, applying defaults.
- * Throws if required fields (`botToken`, `botUsername`) are missing.
+ * Parses `TelegramPluginOptions`, applies defaults, and reports credentials
+ * missing from enabled flows. Credential use is guarded at runtime so
+ * build-time environments can resolve secrets later.
  */
 export function createPluginConfig(
   options: TelegramPluginOptions
@@ -57,17 +58,35 @@ export function createPluginConfig(
     testMode = false,
   } = options;
 
-  if (!botToken) {
-    throw new Error(ERROR_CODES.BOT_TOKEN_REQUIRED.message);
-  }
-
-  if (!botUsername) {
-    throw new Error(ERROR_CODES.BOT_USERNAME_REQUIRED.message);
-  }
-
   const widgetEnabled = loginWidget !== false;
   const miniAppEnabled = miniApp?.enabled ?? false;
   const oidcEnabled = oidc?.enabled ?? false;
+  const resolvedBotToken = botToken ?? "";
+  const resolvedBotUsername = botUsername ?? "";
+
+  if ((widgetEnabled || miniAppEnabled) && !resolvedBotToken) {
+    console.warn(
+      `[better-auth-telegram] ${ERROR_CODES.BOT_TOKEN_REQUIRED.message}. The enabled HMAC flow will reject requests until it is configured.`
+    );
+  }
+
+  if (widgetEnabled && !resolvedBotUsername) {
+    console.warn(
+      `[better-auth-telegram] ${ERROR_CODES.BOT_USERNAME_REQUIRED.message}. The Login Widget cannot be rendered until it is configured.`
+    );
+  }
+
+  if (oidcEnabled && !(oidc?.clientId || resolvedBotToken)) {
+    console.warn(
+      "[better-auth-telegram] OIDC: clientId is required. Configure oidc.clientId or botToken before starting an OIDC login."
+    );
+  }
+
+  if (oidcEnabled && !(oidc?.clientSecret || resolvedBotToken)) {
+    console.warn(
+      "[better-auth-telegram] OIDC: clientSecret is required. Configure oidc.clientSecret or botToken before starting an OIDC login."
+    );
+  }
 
   if (testMode && oidcEnabled) {
     console.warn(
@@ -76,8 +95,8 @@ export function createPluginConfig(
   }
 
   return {
-    botToken,
-    botUsername,
+    botToken: resolvedBotToken,
+    botUsername: resolvedBotUsername,
     widgetEnabled,
     miniAppEnabled,
     oidcEnabled,

--- a/src/types.ts
+++ b/src/types.ts
@@ -59,10 +59,14 @@ export interface TelegramMiniAppData {
 export interface TelegramOIDCClaims {
   aud: string;
   exp: number;
+  family_name?: string;
+  given_name?: string;
   iat: number;
+  id?: number;
   iss: string;
   name?: string;
   phone_number?: string;
+  phone_number_verified?: boolean;
   picture?: string;
   preferred_username?: string;
   sub: string;
@@ -143,13 +147,13 @@ export interface TelegramPluginOptions {
    * Bot token obtained from @BotFather
    * Used for verifying authentication data
    */
-  botToken: string;
+  botToken?: string;
 
   /**
    * Bot username (without @)
    * Used for generating the login widget
    */
-  botUsername: string;
+  botUsername?: string;
 
   /**
    * Enable Login Widget endpoints (signin, link, unlink).

--- a/src/widget-endpoints.test.ts
+++ b/src/widget-endpoints.test.ts
@@ -120,6 +120,17 @@ describe("signInWithTelegram", () => {
     );
   });
 
+  it("rejects use of the Widget flow when botToken is unavailable", async () => {
+    const endpoints = createWidgetEndpoints(makeConfig({ botToken: "" }));
+    const handler = endpoints.signInWithTelegram as any;
+    const ctx = mockCtx(mockAdapter(), TELEGRAM_DATA);
+
+    await expect(handler(ctx)).rejects.toThrow(
+      ERROR_CODES.BOT_TOKEN_REQUIRED.message
+    );
+    expect(mockedVerify).not.toHaveBeenCalled();
+  });
+
   it("rejects failed HMAC verification", async () => {
     mockedVerify.mockResolvedValue(false);
     const endpoints = createWidgetEndpoints(makeConfig());
@@ -341,6 +352,16 @@ describe("linkTelegram", () => {
     await expect((endpoints.linkTelegram as any)(ctx)).rejects.toThrow(
       ERROR_CODES.NOT_AUTHENTICATED.message
     );
+  });
+
+  it("rejects use of the link flow when botToken is unavailable", async () => {
+    const endpoints = createWidgetEndpoints(makeConfig({ botToken: "" }));
+    const ctx = mockCtx(mockAdapter(), TELEGRAM_DATA, session);
+
+    await expect((endpoints.linkTelegram as any)(ctx)).rejects.toThrow(
+      ERROR_CODES.BOT_TOKEN_REQUIRED.message
+    );
+    expect(mockedVerify).not.toHaveBeenCalled();
   });
 
   it("rejects invalid auth data", async () => {

--- a/src/widget-endpoints.ts
+++ b/src/widget-endpoints.ts
@@ -21,6 +21,13 @@ export function createWidgetEndpoints(config: TelegramPluginConfig) {
         method: "POST",
       },
       async (ctx) => {
+        if (!config.botToken) {
+          throw APIError.from(
+            "INTERNAL_SERVER_ERROR",
+            ERROR_CODES.BOT_TOKEN_REQUIRED
+          );
+        }
+
         const body = await ctx.body;
 
         // Validate auth data structure
@@ -171,6 +178,13 @@ export function createWidgetEndpoints(config: TelegramPluginConfig) {
 
         if (!session?.user?.id) {
           throw APIError.from("UNAUTHORIZED", ERROR_CODES.NOT_AUTHENTICATED);
+        }
+
+        if (!config.botToken) {
+          throw APIError.from(
+            "INTERNAL_SERVER_ERROR",
+            ERROR_CODES.BOT_TOKEN_REQUIRED
+          );
         }
 
         // Validate auth data


### PR DESCRIPTION
## What changed

- updates the supported Better Auth range to `>=1.6.22 <1.7.0`
- makes Telegram credentials flow-aware instead of crashing unrelated setups at startup
- adds Mini App auto-sign-in from the `tgWebAppData` hash when the SDK is not present
- updates Telegram OIDC claims and restricts JWT verification to supported, matching algorithms
- refreshes dependencies and documentation without changing existing OIDC account IDs behind users' backs

## Why 2.0.0

The Better Auth security floor drops support for 1.5 and older 1.6 releases. That is a real breaking requirement, so this is a real major release. No semver gymnastics.

We deliberately did not switch persisted OIDC identity from `sub` to Telegram's numeric `id`: doing that without a migration could create duplicate users. That work stays separate and gets the care identity migrations deserve.

## Validation

- `npm ci`
- `npm run prepublishOnly` — typecheck, 344 tests, ESM/CJS/DTS build
- `npm run lint`
- `npm run test:coverage` — 100% statements, lines, and functions; 98.72% branches
- `npm audit --omit=dev` — 0 vulnerabilities
- isolated typecheck, 344 tests, and build against Better Auth 1.6.22
- `npm pack --dry-run`

Closes #26 after the release is published.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Mini App sign-in fallback using data from the URL when Telegram WebApp data is unavailable.
  * Added support for additional Telegram OIDC claims, including names and phone verification status.
  * OIDC-only configurations can now omit widget-specific bot credentials.

* **Bug Fixes**
  * Missing credentials now produce actionable warnings during setup and clear errors when the affected flow is used.
  * Improved OIDC token validation supports RS256, ES256, and EdDSA while rejecting unsupported or mismatched algorithms.

* **Documentation**
  * Updated setup, migration, security, API, and troubleshooting guidance for version 2.0.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->