### PR TITLE
ci: restore the release runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   release:
-    runs-on: [self-hosted, linux, x64, vps]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
The v2.0.0 release job is queued indefinitely because no matching self-hosted runner is available.

This moves only the release job to GitHub-hosted `ubuntu-latest`. The publishing steps and npm/GitHub credentials remain unchanged.

Validation:
- release workflow parses as valid YAML
- change is limited to the runner selector