### PR TITLE
ci: publish releases with npm trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,15 +15,18 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Use Node.js 22.x
+      - name: Use Node.js 24.x
         uses: actions/setup-node@v6
         with:
-          node-version: 22.x
+          node-version: 24.x
           registry-url: https://registry.npmjs.org
-          cache: npm
+          package-manager-cache: false
+
+      - name: Use npm with trusted publishing support
+        run: npm install --global npm@11.18.0
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Type check
         run: npm run type-check
@@ -36,8 +39,6 @@ jobs:
 
       - name: Publish to npm
         run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
The v2.0.0 release reached npm but failed because the old workflow still expected an `NPM_TOKEN`. npm Trusted Publishing is already configured for this repository.

This release workflow now:
- runs on a GitHub-hosted runner required by npm OIDC
- grants `id-token: write` (already present)
- uses Node 24 and npm 11.18.0, above npm’s trusted-publishing minimum
- uses immutable `npm ci` without a release cache
- removes `NODE_AUTH_TOKEN` entirely
- lets npm generate provenance automatically

No package code changes.