### PR TITLE
release: better-auth-telegram v2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the better-auth-telegram plugin will be documented in thi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.0.1] - 2026-07-29
 
 ### Changed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "better-auth-telegram",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "better-auth-telegram",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "2.4.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "better-auth-telegram",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "type": "module",
   "description": "Telegram authentication plugin for Better Auth",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
This publishes the maintenance baseline that landed after v2.0.0:

- Node.js 24 is now the declared package floor
- verified development tooling updates are included in package metadata
- no runtime code changed

Fresh Node 24/npm 11.18 release gate:
- clean npm ci
- lint
- type-check
- 345 tests
- ESM/CJS/DTS build
- production audit: 0 vulnerabilities
- npm pack dry run: 15 files

The one remaining full-audit finding is the known low-severity dev-only esbuild advisory; the fixed esbuild major is outside tsup 8.5.1’s supported range, so there is no forced override.